### PR TITLE
security/upated-on-top-of-2.0.0

### DIFF
--- a/.github/workflows/broken_links_checker.yml
+++ b/.github/workflows/broken_links_checker.yml
@@ -22,7 +22,7 @@ jobs:
     }
     steps:
       - id: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with: {
           persist-credentials: false
         }

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -59,7 +59,7 @@ jobs:
           cache: maven
       - name: Cache SonarCloud packages
         id: cache-sonar
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with: {
           path: ~/.sonar/cache,
           key: '${{ runner.os }}-sonar',
@@ -92,7 +92,35 @@ jobs:
         }
       - name: Verify Release Artifacts
         id: verify-release-artifacts
-        run: "print_message() {\n    local -r message=$1\n    echo \"$message\"\n    echo \"$message\" >> \"$GITHUB_STEP_SUMMARY\"\n}\n\nprint_message \"### Release Artifacts\"\n\nIFS=$'\\n' artifacts_array=($ARTIFACTS)\nmissing_files=()\nfor file in \"${artifacts_array[@]}\";\ndo  \n    echo \"Checking if file $file exists...\"\n    if ! [[ -f \"$file\" ]]; then\n        print_message \"* ⚠️ \\`$file\\` does not exist ⚠️\"\n        echo \"Content of directory $(dirname \"$file\"):\"\n        ls \"$(dirname \"$file\")\"\n        missing_files+=(\"$file\")\n    else\n        print_message \"* \\`$file\\` ✅\" \n    fi\ndone\nprint_message \"\"\nnumber_of_missing_files=${#missing_files[@]}\nif [[ $number_of_missing_files -gt 0 ]]; then\n    print_message \"⚠️ $number_of_missing_files release artifact(s) missing ⚠️\"\n    exit 1\nfi\n"
+        run: |
+          print_message() {
+              local -r message=$1
+              echo "$message"
+              echo "$message" >> "$GITHUB_STEP_SUMMARY"
+          }
+
+          print_message "### Release Artifacts"
+
+          IFS=$'\n' artifacts_array=($ARTIFACTS)
+          missing_files=()
+          for file in "${artifacts_array[@]}";
+          do
+              echo "Checking if file $file exists..."
+              if ! [[ -f "$file" ]]; then
+                  print_message "* ⚠️ \`$file\` does not exist ⚠️"
+                  echo "Content of directory $(dirname "$file"):"
+                  ls "$(dirname "$file")"
+                  missing_files+=("$file")
+              else
+                  print_message "* \`$file\` ✅"
+              fi
+          done
+          print_message ""
+          number_of_missing_files=${#missing_files[@]}
+          if [[ $number_of_missing_files -gt 0 ]]; then
+              print_message "⚠️ $number_of_missing_files release artifact(s) missing ⚠️"
+              exit 1
+          fi
         env: {
           ARTIFACTS: '${{ steps.build-pk-verify.outputs.release-artifacts }}'
         }
@@ -223,7 +251,7 @@ jobs:
         }
       - name: Lint GitHub actions with Zizmore
         id: lint-github-actions
-        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa
         with: {
           advanced-security: false
         }

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -43,7 +43,7 @@ jobs:
           sudo rm -rf /usr/share/dotnet
       - name: Checkout the repository
         id: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with: {
           fetch-depth: 0,
           persist-credentials: false
@@ -137,7 +137,7 @@ jobs:
     steps:
       - name: Checkout the repository
         id: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with: {
           fetch-depth: 0,
           persist-credentials: false
@@ -172,7 +172,7 @@ jobs:
     steps:
       - name: Checkout the repository
         id: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with: {
           persist-credentials: false
         }
@@ -217,13 +217,13 @@ jobs:
     steps:
       - name: Checkout the repository
         id: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with: {
           persist-credentials: false
         }
       - name: Lint GitHub actions with Zizmore
         id: lint-github-actions
-        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d
         with: {
           advanced-security: false
         }
@@ -249,7 +249,7 @@ jobs:
     steps:
       - name: Checkout the repository
         id: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with: {
           fetch-depth: 0,
           persist-credentials: false

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -51,12 +51,11 @@ jobs:
       - name: Set up JDKs
         id: setup-java
         uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: |-
-            17
-            21
+        with: {
+          distribution: temurin,
+          java-version: '21',
           cache: maven
+        }
       - name: Cache SonarCloud packages
         id: cache-sonar
         uses: actions/cache@v6
@@ -207,15 +206,14 @@ jobs:
       - name: Set up JDKs
         id: setup-java
         uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: |-
-            17
-            21
-          cache: maven
-          server-id: ossindex
-          server-username: OSSINDEX_USERNAME
+        with: {
+          distribution: temurin,
+          java-version: '21',
+          cache: maven,
+          server-id: ossindex,
+          server-username: OSSINDEX_USERNAME,
           server-password: OSSINDEX_API_TOKEN
+        }
       - name: Run Ossindex
         id: ossindex
         run: |
@@ -285,12 +283,11 @@ jobs:
       - name: Set up JDKs
         id: setup-java
         uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: |-
-            17
-            21
+        with: {
+          distribution: temurin,
+          java-version: '21',
           cache: maven
+        }
       - name: Check if release is needed
         id: check-release
         if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') }}

--- a/.github/workflows/dependencies_check.yml
+++ b/.github/workflows/dependencies_check.yml
@@ -56,7 +56,7 @@ jobs:
         }
       - name: Create GitHub Issues
         id: create-security-issues
-        uses: exasol/python-toolbox/.github/actions/security-issues@9.0.0
+        uses: exasol/python-toolbox/.github/actions/security-issues@10.1.0
         with: {
           format: maven,
           command: cat ossindex-report.json,

--- a/.github/workflows/dependencies_check.yml
+++ b/.github/workflows/dependencies_check.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with: {
           persist-credentials: false
         }
@@ -56,7 +56,7 @@ jobs:
         }
       - name: Create GitHub Issues
         id: create-security-issues
-        uses: exasol/python-toolbox/.github/actions/security-issues@7.0.0
+        uses: exasol/python-toolbox/.github/actions/security-issues@9.0.0
         with: {
           format: maven,
           command: cat ossindex-report.json,

--- a/.github/workflows/dependencies_check.yml
+++ b/.github/workflows/dependencies_check.yml
@@ -34,15 +34,14 @@ jobs:
       - name: Set up JDKs
         id: setup-jdks
         uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: |-
-            17
-            21
-          cache: maven
-          server-id: ossindex
-          server-username: OSSINDEX_USERNAME
+        with: {
+          distribution: temurin,
+          java-version: '21',
+          cache: maven,
+          server-id: ossindex,
+          server-username: OSSINDEX_USERNAME,
           server-password: OSSINDEX_API_TOKEN
+        }
       - name: Generate ossindex report
         id: ossindex-report
         run: |

--- a/.github/workflows/dependencies_update.yml
+++ b/.github/workflows/dependencies_update.yml
@@ -34,7 +34,7 @@ jobs:
       cancel-in-progress: false
     }
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         id: checkout
         with: {
           fetch-depth: 0,

--- a/.github/workflows/dependencies_update.yml
+++ b/.github/workflows/dependencies_update.yml
@@ -43,12 +43,11 @@ jobs:
       - name: Set up JDKs
         id: setup-jdks
         uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: |-
-            17
-            21
+        with: {
+          distribution: temurin,
+          java-version: '21',
           cache: maven
+        }
       - name: Print issues
         id: debug-print-issues
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
     steps:
       - name: Checkout the repository
         id: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with: {
           fetch-depth: 0,
           persist-credentials: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,26 +84,24 @@ jobs:
         id: configure-maven-central-credentials
         if: ${{ false }}
         uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: |-
-            17
-            21
-          server-id: maven-central-portal
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-          gpg-private-key: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
+        with: {
+          distribution: temurin,
+          java-version: '21',
+          server-id: maven-central-portal,
+          server-username: MAVEN_USERNAME,
+          server-password: MAVEN_PASSWORD,
+          gpg-private-key: '${{ secrets.OSSRH_GPG_SECRET_KEY }}',
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
+        }
       - name: Set up JDKs
         id: setup-jdks
         if: ${{ ! false }}
         uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: |-
-            17
-            21
+        with: {
+          distribution: temurin,
+          java-version: '21',
           cache: maven
+        }
       - name: Fail if not running on main or release branch
         id: check-main-or-release-branch
         if: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/release/') }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -20,6 +20,7 @@ rules:
   obfuscation:
     ignore:
       # Generated workflows use boolean conditions like ${{ false }}
+      # Note: We cannot exclude this using inline comments because GitHubWorkflowIO does not preserve comments in the workflow YAML files.
       - ci-build.yml
       - release.yml
       - project-keeper-verify.yml

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ pom.xml.versionsBackup
 *.flattened-pom.xml
 /.apt_generated/
 /.apt_generated_tests/
+.codex/

--- a/dependencies.md
+++ b/dependencies.md
@@ -35,34 +35,34 @@
 
 ## Plugin Dependencies
 
-| Dependency                                              | License                                     |
-| ------------------------------------------------------- | ------------------------------------------- |
-| [SonarQube Scanner for Maven][39]                       | [GNU LGPL 3][40]                            |
-| [Apache Maven Toolchains Plugin][41]                    | [Apache-2.0][10]                            |
-| [Apache Maven Compiler Plugin][42]                      | [Apache-2.0][10]                            |
-| [Apache Maven Enforcer Plugin][43]                      | [Apache-2.0][10]                            |
-| [Maven Flatten Plugin][44]                              | [Apache Software License][10]               |
-| [org.sonatype.ossindex.maven:ossindex-maven-plugin][45] | [ASL2][29]                                  |
-| [Maven Surefire Plugin][46]                             | [Apache-2.0][10]                            |
-| [Versions Maven Plugin][47]                             | [Apache License, Version 2.0][10]           |
-| [duplicate-finder-maven-plugin Maven Mojo][48]          | [Apache License 2.0][49]                    |
-| [Apache Maven Artifact Plugin][50]                      | [Apache-2.0][10]                            |
-| [Apache Maven Assembly Plugin][51]                      | [Apache-2.0][10]                            |
-| [Apache Maven JAR Plugin][52]                           | [Apache-2.0][10]                            |
-| [OpenFastTrace Maven Plugin][53]                        | [GNU General Public License v3.0][54]       |
-| [Project Keeper Maven plugin][55]                       | [The MIT License][56]                       |
-| [Artifact reference checker and unifier][57]            | [MIT License][58]                           |
-| [Apache Maven Dependency Plugin][59]                    | [Apache-2.0][10]                            |
-| [Maven Failsafe Plugin][60]                             | [Apache-2.0][10]                            |
-| [JaCoCo :: Maven Plugin][61]                            | [EPL-2.0][62]                               |
-| [Quality Summarizer Maven Plugin][63]                   | [MIT License][64]                           |
-| [error-code-crawler-maven-plugin][65]                   | [MIT License][66]                           |
-| [Git Commit Id Maven Plugin][67]                        | [GNU Lesser General Public License 3.0][68] |
-| [Apache Maven Clean Plugin][69]                         | [Apache License, Version 2.0][10]           |
-| [Apache Maven Deploy Plugin][70]                        | [Apache-2.0][10]                            |
-| [Apache Maven Install Plugin][71]                       | [Apache License, Version 2.0][10]           |
-| [Apache Maven Resources Plugin][72]                     | [Apache License, Version 2.0][10]           |
-| [Apache Maven Site Plugin][73]                          | [Apache License, Version 2.0][10]           |
+| Dependency                                              | License                                        |
+| ------------------------------------------------------- | ---------------------------------------------- |
+| [SonarQube Scanner for Maven][39]                       | [GNU LGPL 3][40]                               |
+| [Apache Maven Toolchains Plugin][41]                    | [Apache-2.0][10]                               |
+| [Apache Maven Compiler Plugin][42]                      | [Apache-2.0][10]                               |
+| [Apache Maven Enforcer Plugin][43]                      | [Apache-2.0][10]                               |
+| [Maven Flatten Plugin][44]                              | [Apache Software License][10]                  |
+| [org.sonatype.ossindex.maven:ossindex-maven-plugin][45] | [ASL2][29]                                     |
+| [Maven Surefire Plugin][46]                             | [Apache-2.0][10]                               |
+| [Versions Maven Plugin][47]                             | [Apache License, Version 2.0][10]              |
+| [duplicate-finder-maven-plugin Maven Mojo][48]          | [Apache License 2.0][49]                       |
+| [Apache Maven Artifact Plugin][50]                      | [Apache-2.0][10]                               |
+| [Apache Maven Assembly Plugin][51]                      | [Apache-2.0][10]                               |
+| [Apache Maven JAR Plugin][52]                           | [Apache-2.0][10]                               |
+| [OpenFastTrace Maven Plugin][53]                        | [GNU General Public License v3.0][54]          |
+| [Project Keeper Maven plugin][55]                       | [The MIT License][56]                          |
+| [Artifact reference checker and unifier][57]            | [MIT License][58]                              |
+| [spdx-maven-plugin Maven Plugin][59]                    | [The Apache Software License, Version 2.0][29] |
+| [Apache Maven Dependency Plugin][60]                    | [Apache-2.0][10]                               |
+| [Maven Failsafe Plugin][61]                             | [Apache-2.0][10]                               |
+| [JaCoCo :: Maven Plugin][62]                            | [EPL-2.0][63]                                  |
+| [error-code-crawler-maven-plugin][64]                   | [MIT License][65]                              |
+| [Git Commit Id Maven Plugin][66]                        | [GNU Lesser General Public License 3.0][67]    |
+| [Apache Maven Clean Plugin][68]                         | [Apache License, Version 2.0][10]              |
+| [Apache Maven Deploy Plugin][69]                        | [Apache-2.0][10]                               |
+| [Apache Maven Install Plugin][70]                       | [Apache License, Version 2.0][10]              |
+| [Apache Maven Resources Plugin][71]                     | [Apache License, Version 2.0][10]              |
+| [Apache Maven Site Plugin][72]                          | [Apache License, Version 2.0][10]              |
 
 [0]: https://www.atlassian.com/public-pom/jira-rest-java-client-parent/jira-rest-java-client-core/
 [1]: https://www.apache.org/licenses/LICENSE-2.0
@@ -123,18 +123,17 @@
 [56]: https://github.com/exasol/project-keeper/blob/main/LICENSE
 [57]: https://github.com/exasol/artifact-reference-checker-maven-plugin/
 [58]: https://github.com/exasol/artifact-reference-checker-maven-plugin/blob/main/LICENSE
-[59]: https://maven.apache.org/plugins/maven-dependency-plugin/
-[60]: https://maven.apache.org/surefire/maven-failsafe-plugin/
-[61]: https://www.jacoco.org/jacoco/trunk/doc/maven.html
-[62]: https://www.eclipse.org/legal/epl-2.0/
-[63]: https://github.com/exasol/quality-summarizer-maven-plugin/
-[64]: https://github.com/exasol/quality-summarizer-maven-plugin/blob/main/LICENSE
-[65]: https://github.com/exasol/error-code-crawler-maven-plugin/
-[66]: https://github.com/exasol/error-code-crawler-maven-plugin/blob/main/LICENSE
-[67]: https://github.com/git-commit-id/git-commit-id-maven-plugin
-[68]: http://www.gnu.org/licenses/lgpl-3.0.txt
-[69]: https://maven.apache.org/plugins/maven-clean-plugin/
-[70]: https://maven.apache.org/plugins/maven-deploy-plugin/
-[71]: https://maven.apache.org/plugins/maven-install-plugin/
-[72]: https://maven.apache.org/plugins/maven-resources-plugin/
-[73]: https://maven.apache.org/plugins/maven-site-plugin/
+[59]: https://github.com/spdx/spdx-maven-plugin
+[60]: https://maven.apache.org/plugins/maven-dependency-plugin/
+[61]: https://maven.apache.org/surefire/maven-failsafe-plugin/
+[62]: https://www.jacoco.org/jacoco/trunk/doc/maven.html
+[63]: https://www.eclipse.org/legal/epl-2.0/
+[64]: https://github.com/exasol/error-code-crawler-maven-plugin/
+[65]: https://github.com/exasol/error-code-crawler-maven-plugin/blob/main/LICENSE
+[66]: https://github.com/git-commit-id/git-commit-id-maven-plugin
+[67]: http://www.gnu.org/licenses/lgpl-3.0.txt
+[68]: https://maven.apache.org/plugins/maven-clean-plugin/
+[69]: https://maven.apache.org/plugins/maven-deploy-plugin/
+[70]: https://maven.apache.org/plugins/maven-install-plugin/
+[71]: https://maven.apache.org/plugins/maven-resources-plugin/
+[72]: https://maven.apache.org/plugins/maven-site-plugin/

--- a/dependencies.md
+++ b/dependencies.md
@@ -20,48 +20,48 @@
 | [error-reporting-java][21]                  | [MIT License][22]                                                                                              |
 | [commonmark-java core][23]                  | [BSD-2-Clause][24]                                                                                             |
 | [SnakeYAML][25]                             | [Apache License, Version 2.0][26]                                                                              |
-| [Jansi][27]                                 | [Apache License, Version 2.0][26]                                                                              |
+| [Jansi Bundle][27]                          | [The BSD License][28]                                                                                          |
 
 ## Test Dependencies
 
 | Dependency                                 | License                           |
 | ------------------------------------------ | --------------------------------- |
-| [JUnit Jupiter (Aggregator)][28]           | [Eclipse Public License v2.0][29] |
-| [mockito-junit-jupiter][30]                | [MIT][31]                         |
-| [Hamcrest][32]                             | [BSD-3-Clause][33]                |
-| [Maven Project Version Getter][34]         | [MIT License][35]                 |
-| [EqualsVerifier \| release normal jar][36] | [Apache License, Version 2.0][4]  |
+| [JUnit Jupiter (Aggregator)][29]           | [Eclipse Public License v2.0][30] |
+| [mockito-junit-jupiter][31]                | [MIT][32]                         |
+| [Hamcrest][33]                             | [BSD-3-Clause][34]                |
+| [Maven Project Version Getter][35]         | [MIT License][36]                 |
+| [EqualsVerifier \| release normal jar][37] | [Apache License, Version 2.0][4]  |
 
 ## Plugin Dependencies
 
 | Dependency                                              | License                                        |
 | ------------------------------------------------------- | ---------------------------------------------- |
-| [SonarQube Scanner for Maven][37]                       | [GNU LGPL 3][38]                               |
-| [Apache Maven Toolchains Plugin][39]                    | [Apache-2.0][4]                                |
-| [Apache Maven Compiler Plugin][40]                      | [Apache-2.0][4]                                |
-| [Apache Maven Enforcer Plugin][41]                      | [Apache-2.0][4]                                |
-| [Maven Flatten Plugin][42]                              | [Apache Software License][4]                   |
-| [org.sonatype.ossindex.maven:ossindex-maven-plugin][43] | [ASL2][26]                                     |
-| [Maven Surefire Plugin][44]                             | [Apache-2.0][4]                                |
-| [Versions Maven Plugin][45]                             | [Apache License, Version 2.0][4]               |
-| [duplicate-finder-maven-plugin Maven Mojo][46]          | [Apache License 2.0][47]                       |
-| [Apache Maven Artifact Plugin][48]                      | [Apache-2.0][4]                                |
-| [Apache Maven Assembly Plugin][49]                      | [Apache-2.0][4]                                |
-| [Apache Maven JAR Plugin][50]                           | [Apache-2.0][4]                                |
-| [OpenFastTrace Maven Plugin][51]                        | [GNU General Public License v3.0][52]          |
-| [Project Keeper Maven plugin][53]                       | [The MIT License][54]                          |
-| [Artifact reference checker and unifier][55]            | [MIT License][56]                              |
-| [spdx-maven-plugin Maven Plugin][57]                    | [The Apache Software License, Version 2.0][26] |
-| [Apache Maven Dependency Plugin][58]                    | [Apache-2.0][4]                                |
-| [Maven Failsafe Plugin][59]                             | [Apache-2.0][4]                                |
-| [JaCoCo :: Maven Plugin][60]                            | [EPL-2.0][61]                                  |
-| [error-code-crawler-maven-plugin][62]                   | [MIT License][63]                              |
-| [Git Commit Id Maven Plugin][64]                        | [GNU Lesser General Public License 3.0][65]    |
-| [Apache Maven Clean Plugin][66]                         | [Apache License, Version 2.0][4]               |
-| [Apache Maven Deploy Plugin][67]                        | [Apache-2.0][4]                                |
-| [Apache Maven Install Plugin][68]                       | [Apache License, Version 2.0][4]               |
-| [Apache Maven Resources Plugin][69]                     | [Apache License, Version 2.0][4]               |
-| [Apache Maven Site Plugin][70]                          | [Apache License, Version 2.0][4]               |
+| [SonarQube Scanner for Maven][38]                       | [GNU LGPL 3][39]                               |
+| [Apache Maven Toolchains Plugin][40]                    | [Apache-2.0][4]                                |
+| [Apache Maven Compiler Plugin][41]                      | [Apache-2.0][4]                                |
+| [Apache Maven Enforcer Plugin][42]                      | [Apache-2.0][4]                                |
+| [Maven Flatten Plugin][43]                              | [Apache Software License][4]                   |
+| [org.sonatype.ossindex.maven:ossindex-maven-plugin][44] | [ASL2][26]                                     |
+| [Maven Surefire Plugin][45]                             | [Apache-2.0][4]                                |
+| [Versions Maven Plugin][46]                             | [Apache License, Version 2.0][4]               |
+| [duplicate-finder-maven-plugin Maven Mojo][47]          | [Apache License 2.0][48]                       |
+| [Apache Maven Artifact Plugin][49]                      | [Apache-2.0][4]                                |
+| [Apache Maven Assembly Plugin][50]                      | [Apache-2.0][4]                                |
+| [Apache Maven JAR Plugin][51]                           | [Apache-2.0][4]                                |
+| [OpenFastTrace Maven Plugin][52]                        | [GNU General Public License v3.0][53]          |
+| [Project Keeper Maven plugin][54]                       | [The MIT License][55]                          |
+| [Artifact reference checker and unifier][56]            | [MIT License][57]                              |
+| [spdx-maven-plugin Maven Plugin][58]                    | [The Apache Software License, Version 2.0][26] |
+| [Apache Maven Dependency Plugin][59]                    | [Apache-2.0][4]                                |
+| [Maven Failsafe Plugin][60]                             | [Apache-2.0][4]                                |
+| [JaCoCo :: Maven Plugin][61]                            | [EPL-2.0][62]                                  |
+| [error-code-crawler-maven-plugin][63]                   | [MIT License][64]                              |
+| [Git Commit Id Maven Plugin][65]                        | [GNU Lesser General Public License 3.0][66]    |
+| [Apache Maven Clean Plugin][67]                         | [Apache License, Version 2.0][4]               |
+| [Apache Maven Deploy Plugin][68]                        | [Apache-2.0][4]                                |
+| [Apache Maven Install Plugin][69]                       | [Apache License, Version 2.0][4]               |
+| [Apache Maven Resources Plugin][70]                     | [Apache License, Version 2.0][4]               |
+| [Apache Maven Site Plugin][71]                          | [Apache License, Version 2.0][4]               |
 
 [0]: https://www.atlassian.com/public-pom/jira-rest-java-client-parent/jira-rest-java-client-core/
 [1]: https://www.apache.org/licenses/LICENSE-2.0
@@ -90,47 +90,48 @@
 [24]: https://opensource.org/licenses/BSD-2-Clause
 [25]: https://bitbucket.org/snakeyaml/snakeyaml
 [26]: http://www.apache.org/licenses/LICENSE-2.0.txt
-[27]: http://fusesource.github.io/jansi
-[28]: https://junit.org/
-[29]: https://www.eclipse.org/legal/epl-v20.html
-[30]: https://github.com/mockito/mockito
-[31]: https://opensource.org/licenses/MIT
-[32]: http://hamcrest.org/JavaHamcrest/
-[33]: https://raw.githubusercontent.com/hamcrest/JavaHamcrest/master/LICENSE
-[34]: https://github.com/exasol/maven-project-version-getter/
-[35]: https://github.com/exasol/maven-project-version-getter/blob/main/LICENSE
-[36]: https://www.jqno.nl/equalsverifier
-[37]: https://docs.sonarsource.com/sonarqube-server/latest/extension-guide/developing-a-plugin/plugin-basics/sonar-scanner-maven/sonar-maven-plugin/
-[38]: http://www.gnu.org/licenses/lgpl.txt
-[39]: https://maven.apache.org/plugins/maven-toolchains-plugin/
-[40]: https://maven.apache.org/plugins/maven-compiler-plugin/
-[41]: https://maven.apache.org/enforcer/maven-enforcer-plugin/
-[42]: https://www.mojohaus.org/flatten-maven-plugin/
-[43]: https://sonatype.github.io/ossindex-maven/maven-plugin/
-[44]: https://maven.apache.org/surefire/maven-surefire-plugin/
-[45]: https://www.mojohaus.org/versions/versions-maven-plugin/
-[46]: https://basepom.github.io/duplicate-finder-maven-plugin
-[47]: http://www.apache.org/licenses/LICENSE-2.0.html
-[48]: https://maven.apache.org/plugins/maven-artifact-plugin/
-[49]: https://maven.apache.org/plugins/maven-assembly-plugin/
-[50]: https://maven.apache.org/plugins/maven-jar-plugin/
-[51]: https://github.com/itsallcode/openfasttrace-maven-plugin
-[52]: https://www.gnu.org/licenses/gpl-3.0.html
-[53]: https://github.com/exasol/project-keeper/
-[54]: https://github.com/exasol/project-keeper/blob/main/LICENSE
-[55]: https://github.com/exasol/artifact-reference-checker-maven-plugin/
-[56]: https://github.com/exasol/artifact-reference-checker-maven-plugin/blob/main/LICENSE
-[57]: https://github.com/spdx/spdx-maven-plugin
-[58]: https://maven.apache.org/plugins/maven-dependency-plugin/
-[59]: https://maven.apache.org/surefire/maven-failsafe-plugin/
-[60]: https://www.jacoco.org/jacoco/trunk/doc/maven.html
-[61]: https://www.eclipse.org/legal/epl-2.0/
-[62]: https://github.com/exasol/error-code-crawler-maven-plugin/
-[63]: https://github.com/exasol/error-code-crawler-maven-plugin/blob/main/LICENSE
-[64]: https://github.com/git-commit-id/git-commit-id-maven-plugin
-[65]: http://www.gnu.org/licenses/lgpl-3.0.txt
-[66]: https://maven.apache.org/plugins/maven-clean-plugin/
-[67]: https://maven.apache.org/plugins/maven-deploy-plugin/
-[68]: https://maven.apache.org/plugins/maven-install-plugin/
-[69]: https://maven.apache.org/plugins/maven-resources-plugin/
-[70]: https://maven.apache.org/plugins/maven-site-plugin/
+[27]: https://github.com/jline/jline3/jansi
+[28]: https://opensource.org/licenses/BSD-3-Clause
+[29]: https://junit.org/
+[30]: https://www.eclipse.org/legal/epl-v20.html
+[31]: https://github.com/mockito/mockito
+[32]: https://opensource.org/licenses/MIT
+[33]: http://hamcrest.org/JavaHamcrest/
+[34]: https://raw.githubusercontent.com/hamcrest/JavaHamcrest/master/LICENSE
+[35]: https://github.com/exasol/maven-project-version-getter/
+[36]: https://github.com/exasol/maven-project-version-getter/blob/main/LICENSE
+[37]: https://www.jqno.nl/equalsverifier
+[38]: https://docs.sonarsource.com/sonarqube-server/latest/extension-guide/developing-a-plugin/plugin-basics/sonar-scanner-maven/sonar-maven-plugin/
+[39]: http://www.gnu.org/licenses/lgpl.txt
+[40]: https://maven.apache.org/plugins/maven-toolchains-plugin/
+[41]: https://maven.apache.org/plugins/maven-compiler-plugin/
+[42]: https://maven.apache.org/enforcer/maven-enforcer-plugin/
+[43]: https://www.mojohaus.org/flatten-maven-plugin/
+[44]: https://sonatype.github.io/ossindex-maven/maven-plugin/
+[45]: https://maven.apache.org/surefire/maven-surefire-plugin/
+[46]: https://www.mojohaus.org/versions/versions-maven-plugin/
+[47]: https://basepom.github.io/duplicate-finder-maven-plugin
+[48]: http://www.apache.org/licenses/LICENSE-2.0.html
+[49]: https://maven.apache.org/plugins/maven-artifact-plugin/
+[50]: https://maven.apache.org/plugins/maven-assembly-plugin/
+[51]: https://maven.apache.org/plugins/maven-jar-plugin/
+[52]: https://github.com/itsallcode/openfasttrace-maven-plugin
+[53]: https://www.gnu.org/licenses/gpl-3.0.html
+[54]: https://github.com/exasol/project-keeper/
+[55]: https://github.com/exasol/project-keeper/blob/main/LICENSE
+[56]: https://github.com/exasol/artifact-reference-checker-maven-plugin/
+[57]: https://github.com/exasol/artifact-reference-checker-maven-plugin/blob/main/LICENSE
+[58]: https://github.com/spdx/spdx-maven-plugin
+[59]: https://maven.apache.org/plugins/maven-dependency-plugin/
+[60]: https://maven.apache.org/surefire/maven-failsafe-plugin/
+[61]: https://www.jacoco.org/jacoco/trunk/doc/maven.html
+[62]: https://www.eclipse.org/legal/epl-2.0/
+[63]: https://github.com/exasol/error-code-crawler-maven-plugin/
+[64]: https://github.com/exasol/error-code-crawler-maven-plugin/blob/main/LICENSE
+[65]: https://github.com/git-commit-id/git-commit-id-maven-plugin
+[66]: http://www.gnu.org/licenses/lgpl-3.0.txt
+[67]: https://maven.apache.org/plugins/maven-clean-plugin/
+[68]: https://maven.apache.org/plugins/maven-deploy-plugin/
+[69]: https://maven.apache.org/plugins/maven-install-plugin/
+[70]: https://maven.apache.org/plugins/maven-resources-plugin/
+[71]: https://maven.apache.org/plugins/maven-site-plugin/

--- a/dependencies.md
+++ b/dependencies.md
@@ -53,15 +53,15 @@
 | [Artifact reference checker and unifier][56]            | [MIT License][57]                              |
 | [spdx-maven-plugin Maven Plugin][58]                    | [The Apache Software License, Version 2.0][26] |
 | [Apache Maven Dependency Plugin][59]                    | [Apache-2.0][4]                                |
-| [Maven Failsafe Plugin][60]                             | [Apache-2.0][4]                                |
-| [JaCoCo :: Maven Plugin][61]                            | [EPL-2.0][62]                                  |
-| [error-code-crawler-maven-plugin][63]                   | [MIT License][64]                              |
-| [Git Commit Id Maven Plugin][65]                        | [GNU Lesser General Public License 3.0][66]    |
-| [Apache Maven Clean Plugin][67]                         | [Apache License, Version 2.0][4]               |
-| [Apache Maven Deploy Plugin][68]                        | [Apache-2.0][4]                                |
-| [Apache Maven Install Plugin][69]                       | [Apache License, Version 2.0][4]               |
-| [Apache Maven Resources Plugin][70]                     | [Apache License, Version 2.0][4]               |
-| [Apache Maven Site Plugin][71]                          | [Apache License, Version 2.0][4]               |
+| [Apache Maven Clean Plugin][60]                         | [Apache License, Version 2.0][4]               |
+| [Apache Maven Deploy Plugin][61]                        | [Apache-2.0][4]                                |
+| [Apache Maven Install Plugin][62]                       | [Apache License, Version 2.0][4]               |
+| [Apache Maven Resources Plugin][63]                     | [Apache License, Version 2.0][4]               |
+| [Apache Maven Site Plugin][64]                          | [Apache License, Version 2.0][4]               |
+| [Maven Failsafe Plugin][65]                             | [Apache-2.0][4]                                |
+| [JaCoCo :: Maven Plugin][66]                            | [EPL-2.0][67]                                  |
+| [error-code-crawler-maven-plugin][68]                   | [MIT License][69]                              |
+| [Git Commit Id Maven Plugin][70]                        | [GNU Lesser General Public License 3.0][71]    |
 
 [0]: https://www.atlassian.com/public-pom/jira-rest-java-client-parent/jira-rest-java-client-core/
 [1]: https://www.apache.org/licenses/LICENSE-2.0
@@ -123,15 +123,15 @@
 [57]: https://github.com/exasol/artifact-reference-checker-maven-plugin/blob/main/LICENSE
 [58]: https://github.com/spdx/spdx-maven-plugin
 [59]: https://maven.apache.org/plugins/maven-dependency-plugin/
-[60]: https://maven.apache.org/surefire/maven-failsafe-plugin/
-[61]: https://www.jacoco.org/jacoco/trunk/doc/maven.html
-[62]: https://www.eclipse.org/legal/epl-2.0/
-[63]: https://github.com/exasol/error-code-crawler-maven-plugin/
-[64]: https://github.com/exasol/error-code-crawler-maven-plugin/blob/main/LICENSE
-[65]: https://github.com/git-commit-id/git-commit-id-maven-plugin
-[66]: http://www.gnu.org/licenses/lgpl-3.0.txt
-[67]: https://maven.apache.org/plugins/maven-clean-plugin/
-[68]: https://maven.apache.org/plugins/maven-deploy-plugin/
-[69]: https://maven.apache.org/plugins/maven-install-plugin/
-[70]: https://maven.apache.org/plugins/maven-resources-plugin/
-[71]: https://maven.apache.org/plugins/maven-site-plugin/
+[60]: https://maven.apache.org/plugins/maven-clean-plugin/
+[61]: https://maven.apache.org/plugins/maven-deploy-plugin/
+[62]: https://maven.apache.org/plugins/maven-install-plugin/
+[63]: https://maven.apache.org/plugins/maven-resources-plugin/
+[64]: https://maven.apache.org/plugins/maven-site-plugin/
+[65]: https://maven.apache.org/surefire/maven-failsafe-plugin/
+[66]: https://www.jacoco.org/jacoco/trunk/doc/maven.html
+[67]: https://www.eclipse.org/legal/epl-2.0/
+[68]: https://github.com/exasol/error-code-crawler-maven-plugin/
+[69]: https://github.com/exasol/error-code-crawler-maven-plugin/blob/main/LICENSE
+[70]: https://github.com/git-commit-id/git-commit-id-maven-plugin
+[71]: http://www.gnu.org/licenses/lgpl-3.0.txt

--- a/dependencies.md
+++ b/dependencies.md
@@ -17,51 +17,50 @@
 | [Yasson][14]                                | [Eclipse Public License v. 2.0][15]; [Eclipse Distribution License v. 1.0][16]                                 |
 | [Eclipse Parsson][17]                       | [Eclipse Public License 2.0][18]; [GNU General Public License, version 2 with the GNU Classpath Exception][19] |
 | [Maven Model][20]                           | [Apache-2.0][4]                                                                                                |
-| [error-reporting-java][21]                  | [MIT License][22]                                                                                              |
-| [commonmark-java core][23]                  | [BSD-2-Clause][24]                                                                                             |
-| [SnakeYAML][25]                             | [Apache License, Version 2.0][26]                                                                              |
-| [Jansi Bundle][27]                          | [The BSD License][28]                                                                                          |
+| [commonmark-java core][21]                  | [BSD-2-Clause][22]                                                                                             |
+| [SnakeYAML][23]                             | [Apache License, Version 2.0][24]                                                                              |
+| [Jansi Bundle][25]                          | [The BSD License][26]                                                                                          |
 
 ## Test Dependencies
 
 | Dependency                                 | License                           |
 | ------------------------------------------ | --------------------------------- |
-| [JUnit Jupiter (Aggregator)][29]           | [Eclipse Public License v2.0][30] |
-| [mockito-junit-jupiter][31]                | [MIT][32]                         |
-| [Hamcrest][33]                             | [BSD-3-Clause][34]                |
-| [Maven Project Version Getter][35]         | [MIT License][36]                 |
-| [EqualsVerifier \| release normal jar][37] | [Apache License, Version 2.0][4]  |
+| [JUnit Jupiter (Aggregator)][27]           | [Eclipse Public License v2.0][28] |
+| [mockito-junit-jupiter][29]                | [MIT][30]                         |
+| [Hamcrest][31]                             | [BSD-3-Clause][32]                |
+| [Maven Project Version Getter][33]         | [MIT License][34]                 |
+| [EqualsVerifier \| release normal jar][35] | [Apache License, Version 2.0][4]  |
 
 ## Plugin Dependencies
 
 | Dependency                                              | License                                        |
 | ------------------------------------------------------- | ---------------------------------------------- |
-| [SonarQube Scanner for Maven][38]                       | [GNU LGPL 3][39]                               |
-| [Apache Maven Toolchains Plugin][40]                    | [Apache-2.0][4]                                |
-| [Apache Maven Compiler Plugin][41]                      | [Apache-2.0][4]                                |
-| [Apache Maven Enforcer Plugin][42]                      | [Apache-2.0][4]                                |
-| [Maven Flatten Plugin][43]                              | [Apache Software License][4]                   |
-| [org.sonatype.ossindex.maven:ossindex-maven-plugin][44] | [ASL2][26]                                     |
-| [Maven Surefire Plugin][45]                             | [Apache-2.0][4]                                |
-| [Versions Maven Plugin][46]                             | [Apache License, Version 2.0][4]               |
-| [duplicate-finder-maven-plugin Maven Mojo][47]          | [Apache License 2.0][48]                       |
-| [Apache Maven Artifact Plugin][49]                      | [Apache-2.0][4]                                |
-| [Apache Maven Assembly Plugin][50]                      | [Apache-2.0][4]                                |
-| [Apache Maven JAR Plugin][51]                           | [Apache-2.0][4]                                |
-| [OpenFastTrace Maven Plugin][52]                        | [GNU General Public License v3.0][53]          |
-| [Project Keeper Maven plugin][54]                       | [The MIT License][55]                          |
-| [Artifact reference checker and unifier][56]            | [MIT License][57]                              |
-| [spdx-maven-plugin Maven Plugin][58]                    | [The Apache Software License, Version 2.0][26] |
-| [Apache Maven Dependency Plugin][59]                    | [Apache-2.0][4]                                |
-| [Maven Failsafe Plugin][60]                             | [Apache-2.0][4]                                |
-| [JaCoCo :: Maven Plugin][61]                            | [EPL-2.0][62]                                  |
-| [error-code-crawler-maven-plugin][63]                   | [MIT License][64]                              |
-| [Git Commit Id Maven Plugin][65]                        | [GNU Lesser General Public License 3.0][66]    |
-| [Apache Maven Clean Plugin][67]                         | [Apache License, Version 2.0][4]               |
-| [Apache Maven Deploy Plugin][68]                        | [Apache-2.0][4]                                |
-| [Apache Maven Install Plugin][69]                       | [Apache License, Version 2.0][4]               |
-| [Apache Maven Resources Plugin][70]                     | [Apache License, Version 2.0][4]               |
-| [Apache Maven Site Plugin][71]                          | [Apache License, Version 2.0][4]               |
+| [SonarQube Scanner for Maven][36]                       | [GNU LGPL 3][37]                               |
+| [Apache Maven Toolchains Plugin][38]                    | [Apache-2.0][4]                                |
+| [Apache Maven Compiler Plugin][39]                      | [Apache-2.0][4]                                |
+| [Apache Maven Enforcer Plugin][40]                      | [Apache-2.0][4]                                |
+| [Maven Flatten Plugin][41]                              | [Apache Software License][4]                   |
+| [org.sonatype.ossindex.maven:ossindex-maven-plugin][42] | [ASL2][24]                                     |
+| [Maven Surefire Plugin][43]                             | [Apache-2.0][4]                                |
+| [Versions Maven Plugin][44]                             | [Apache License, Version 2.0][4]               |
+| [duplicate-finder-maven-plugin Maven Mojo][45]          | [Apache License 2.0][46]                       |
+| [Apache Maven Artifact Plugin][47]                      | [Apache-2.0][4]                                |
+| [Apache Maven Assembly Plugin][48]                      | [Apache-2.0][4]                                |
+| [Apache Maven JAR Plugin][49]                           | [Apache-2.0][4]                                |
+| [OpenFastTrace Maven Plugin][50]                        | [GNU General Public License v3.0][51]          |
+| [Project Keeper Maven plugin][52]                       | [The MIT License][53]                          |
+| [Artifact reference checker and unifier][54]            | [MIT License][55]                              |
+| [spdx-maven-plugin Maven Plugin][56]                    | [The Apache Software License, Version 2.0][24] |
+| [Apache Maven Dependency Plugin][57]                    | [Apache-2.0][4]                                |
+| [Maven Failsafe Plugin][58]                             | [Apache-2.0][4]                                |
+| [JaCoCo :: Maven Plugin][59]                            | [EPL-2.0][60]                                  |
+| [error-code-crawler-maven-plugin][61]                   | [MIT License][62]                              |
+| [Git Commit Id Maven Plugin][63]                        | [GNU Lesser General Public License 3.0][64]    |
+| [Apache Maven Clean Plugin][65]                         | [Apache License, Version 2.0][4]               |
+| [Apache Maven Deploy Plugin][66]                        | [Apache-2.0][4]                                |
+| [Apache Maven Install Plugin][67]                       | [Apache License, Version 2.0][4]               |
+| [Apache Maven Resources Plugin][68]                     | [Apache License, Version 2.0][4]               |
+| [Apache Maven Site Plugin][69]                          | [Apache License, Version 2.0][4]               |
 
 [0]: https://www.atlassian.com/public-pom/jira-rest-java-client-parent/jira-rest-java-client-core/
 [1]: https://www.apache.org/licenses/LICENSE-2.0
@@ -84,54 +83,52 @@
 [18]: https://projects.eclipse.org/license/epl-2.0
 [19]: https://projects.eclipse.org/license/secondary-gpl-2.0-cp
 [20]: https://maven.apache.org/ref/3.9.16/maven-model/
-[21]: https://github.com/exasol/error-reporting-java/
-[22]: https://github.com/exasol/error-reporting-java/blob/main/LICENSE
-[23]: https://github.com/commonmark/commonmark-java/commonmark
-[24]: https://opensource.org/licenses/BSD-2-Clause
-[25]: https://bitbucket.org/snakeyaml/snakeyaml
-[26]: http://www.apache.org/licenses/LICENSE-2.0.txt
-[27]: https://github.com/jline/jline3/jansi
-[28]: https://opensource.org/licenses/BSD-3-Clause
-[29]: https://junit.org/
-[30]: https://www.eclipse.org/legal/epl-v20.html
-[31]: https://github.com/mockito/mockito
-[32]: https://opensource.org/licenses/MIT
-[33]: http://hamcrest.org/JavaHamcrest/
-[34]: https://raw.githubusercontent.com/hamcrest/JavaHamcrest/master/LICENSE
-[35]: https://github.com/exasol/maven-project-version-getter/
-[36]: https://github.com/exasol/maven-project-version-getter/blob/main/LICENSE
-[37]: https://www.jqno.nl/equalsverifier
-[38]: https://docs.sonarsource.com/sonarqube-server/latest/extension-guide/developing-a-plugin/plugin-basics/sonar-scanner-maven/sonar-maven-plugin/
-[39]: http://www.gnu.org/licenses/lgpl.txt
-[40]: https://maven.apache.org/plugins/maven-toolchains-plugin/
-[41]: https://maven.apache.org/plugins/maven-compiler-plugin/
-[42]: https://maven.apache.org/enforcer/maven-enforcer-plugin/
-[43]: https://www.mojohaus.org/flatten-maven-plugin/
-[44]: https://sonatype.github.io/ossindex-maven/maven-plugin/
-[45]: https://maven.apache.org/surefire/maven-surefire-plugin/
-[46]: https://www.mojohaus.org/versions/versions-maven-plugin/
-[47]: https://basepom.github.io/duplicate-finder-maven-plugin
-[48]: http://www.apache.org/licenses/LICENSE-2.0.html
-[49]: https://maven.apache.org/plugins/maven-artifact-plugin/
-[50]: https://maven.apache.org/plugins/maven-assembly-plugin/
-[51]: https://maven.apache.org/plugins/maven-jar-plugin/
-[52]: https://github.com/itsallcode/openfasttrace-maven-plugin
-[53]: https://www.gnu.org/licenses/gpl-3.0.html
-[54]: https://github.com/exasol/project-keeper/
-[55]: https://github.com/exasol/project-keeper/blob/main/LICENSE
-[56]: https://github.com/exasol/artifact-reference-checker-maven-plugin/
-[57]: https://github.com/exasol/artifact-reference-checker-maven-plugin/blob/main/LICENSE
-[58]: https://github.com/spdx/spdx-maven-plugin
-[59]: https://maven.apache.org/plugins/maven-dependency-plugin/
-[60]: https://maven.apache.org/surefire/maven-failsafe-plugin/
-[61]: https://www.jacoco.org/jacoco/trunk/doc/maven.html
-[62]: https://www.eclipse.org/legal/epl-2.0/
-[63]: https://github.com/exasol/error-code-crawler-maven-plugin/
-[64]: https://github.com/exasol/error-code-crawler-maven-plugin/blob/main/LICENSE
-[65]: https://github.com/git-commit-id/git-commit-id-maven-plugin
-[66]: http://www.gnu.org/licenses/lgpl-3.0.txt
-[67]: https://maven.apache.org/plugins/maven-clean-plugin/
-[68]: https://maven.apache.org/plugins/maven-deploy-plugin/
-[69]: https://maven.apache.org/plugins/maven-install-plugin/
-[70]: https://maven.apache.org/plugins/maven-resources-plugin/
-[71]: https://maven.apache.org/plugins/maven-site-plugin/
+[21]: https://github.com/commonmark/commonmark-java/commonmark
+[22]: https://opensource.org/licenses/BSD-2-Clause
+[23]: https://bitbucket.org/snakeyaml/snakeyaml
+[24]: http://www.apache.org/licenses/LICENSE-2.0.txt
+[25]: https://github.com/jline/jline3/jansi
+[26]: https://opensource.org/licenses/BSD-3-Clause
+[27]: https://junit.org/
+[28]: https://www.eclipse.org/legal/epl-v20.html
+[29]: https://github.com/mockito/mockito
+[30]: https://opensource.org/licenses/MIT
+[31]: http://hamcrest.org/JavaHamcrest/
+[32]: https://raw.githubusercontent.com/hamcrest/JavaHamcrest/master/LICENSE
+[33]: https://github.com/exasol/maven-project-version-getter/
+[34]: https://github.com/exasol/maven-project-version-getter/blob/main/LICENSE
+[35]: https://www.jqno.nl/equalsverifier
+[36]: https://docs.sonarsource.com/sonarqube-server/latest/extension-guide/developing-a-plugin/plugin-basics/sonar-scanner-maven/sonar-maven-plugin/
+[37]: http://www.gnu.org/licenses/lgpl.txt
+[38]: https://maven.apache.org/plugins/maven-toolchains-plugin/
+[39]: https://maven.apache.org/plugins/maven-compiler-plugin/
+[40]: https://maven.apache.org/enforcer/maven-enforcer-plugin/
+[41]: https://www.mojohaus.org/flatten-maven-plugin/
+[42]: https://sonatype.github.io/ossindex-maven/maven-plugin/
+[43]: https://maven.apache.org/surefire/maven-surefire-plugin/
+[44]: https://www.mojohaus.org/versions/versions-maven-plugin/
+[45]: https://basepom.github.io/duplicate-finder-maven-plugin
+[46]: http://www.apache.org/licenses/LICENSE-2.0.html
+[47]: https://maven.apache.org/plugins/maven-artifact-plugin/
+[48]: https://maven.apache.org/plugins/maven-assembly-plugin/
+[49]: https://maven.apache.org/plugins/maven-jar-plugin/
+[50]: https://github.com/itsallcode/openfasttrace-maven-plugin
+[51]: https://www.gnu.org/licenses/gpl-3.0.html
+[52]: https://github.com/exasol/project-keeper/
+[53]: https://github.com/exasol/project-keeper/blob/main/LICENSE
+[54]: https://github.com/exasol/artifact-reference-checker-maven-plugin/
+[55]: https://github.com/exasol/artifact-reference-checker-maven-plugin/blob/main/LICENSE
+[56]: https://github.com/spdx/spdx-maven-plugin
+[57]: https://maven.apache.org/plugins/maven-dependency-plugin/
+[58]: https://maven.apache.org/surefire/maven-failsafe-plugin/
+[59]: https://www.jacoco.org/jacoco/trunk/doc/maven.html
+[60]: https://www.eclipse.org/legal/epl-2.0/
+[61]: https://github.com/exasol/error-code-crawler-maven-plugin/
+[62]: https://github.com/exasol/error-code-crawler-maven-plugin/blob/main/LICENSE
+[63]: https://github.com/git-commit-id/git-commit-id-maven-plugin
+[64]: http://www.gnu.org/licenses/lgpl-3.0.txt
+[65]: https://maven.apache.org/plugins/maven-clean-plugin/
+[66]: https://maven.apache.org/plugins/maven-deploy-plugin/
+[67]: https://maven.apache.org/plugins/maven-install-plugin/
+[68]: https://maven.apache.org/plugins/maven-resources-plugin/
+[69]: https://maven.apache.org/plugins/maven-site-plugin/

--- a/dependencies.md
+++ b/dependencies.md
@@ -17,50 +17,51 @@
 | [Yasson][14]                                | [Eclipse Public License v. 2.0][15]; [Eclipse Distribution License v. 1.0][16]                                 |
 | [Eclipse Parsson][17]                       | [Eclipse Public License 2.0][18]; [GNU General Public License, version 2 with the GNU Classpath Exception][19] |
 | [Maven Model][20]                           | [Apache-2.0][4]                                                                                                |
-| [commonmark-java core][21]                  | [BSD-2-Clause][22]                                                                                             |
-| [SnakeYAML][23]                             | [Apache License, Version 2.0][24]                                                                              |
-| [Jansi Bundle][25]                          | [The BSD License][26]                                                                                          |
+| [error-reporting-java][21]                  | [MIT License][22]                                                                                              |
+| [commonmark-java core][23]                  | [BSD-2-Clause][24]                                                                                             |
+| [SnakeYAML][25]                             | [Apache License, Version 2.0][26]                                                                              |
+| [Jansi Bundle][27]                          | [The BSD License][28]                                                                                          |
 
 ## Test Dependencies
 
 | Dependency                                 | License                           |
 | ------------------------------------------ | --------------------------------- |
-| [JUnit Jupiter (Aggregator)][27]           | [Eclipse Public License v2.0][28] |
-| [mockito-junit-jupiter][29]                | [MIT][30]                         |
-| [Hamcrest][31]                             | [BSD-3-Clause][32]                |
-| [Maven Project Version Getter][33]         | [MIT License][34]                 |
-| [EqualsVerifier \| release normal jar][35] | [Apache License, Version 2.0][4]  |
+| [JUnit Jupiter (Aggregator)][29]           | [Eclipse Public License v2.0][30] |
+| [mockito-junit-jupiter][31]                | [MIT][32]                         |
+| [Hamcrest][33]                             | [BSD-3-Clause][34]                |
+| [Maven Project Version Getter][35]         | [MIT License][36]                 |
+| [EqualsVerifier \| release normal jar][37] | [Apache License, Version 2.0][4]  |
 
 ## Plugin Dependencies
 
 | Dependency                                              | License                                        |
 | ------------------------------------------------------- | ---------------------------------------------- |
-| [SonarQube Scanner for Maven][36]                       | [GNU LGPL 3][37]                               |
-| [Apache Maven Toolchains Plugin][38]                    | [Apache-2.0][4]                                |
-| [Apache Maven Compiler Plugin][39]                      | [Apache-2.0][4]                                |
-| [Apache Maven Enforcer Plugin][40]                      | [Apache-2.0][4]                                |
-| [Maven Flatten Plugin][41]                              | [Apache Software License][4]                   |
-| [org.sonatype.ossindex.maven:ossindex-maven-plugin][42] | [ASL2][24]                                     |
-| [Maven Surefire Plugin][43]                             | [Apache-2.0][4]                                |
-| [Versions Maven Plugin][44]                             | [Apache License, Version 2.0][4]               |
-| [duplicate-finder-maven-plugin Maven Mojo][45]          | [Apache License 2.0][46]                       |
-| [Apache Maven Artifact Plugin][47]                      | [Apache-2.0][4]                                |
-| [Apache Maven Assembly Plugin][48]                      | [Apache-2.0][4]                                |
-| [Apache Maven JAR Plugin][49]                           | [Apache-2.0][4]                                |
-| [OpenFastTrace Maven Plugin][50]                        | [GNU General Public License v3.0][51]          |
-| [Project Keeper Maven plugin][52]                       | [The MIT License][53]                          |
-| [Artifact reference checker and unifier][54]            | [MIT License][55]                              |
-| [spdx-maven-plugin Maven Plugin][56]                    | [The Apache Software License, Version 2.0][24] |
-| [Apache Maven Dependency Plugin][57]                    | [Apache-2.0][4]                                |
-| [Maven Failsafe Plugin][58]                             | [Apache-2.0][4]                                |
-| [JaCoCo :: Maven Plugin][59]                            | [EPL-2.0][60]                                  |
-| [error-code-crawler-maven-plugin][61]                   | [MIT License][62]                              |
-| [Git Commit Id Maven Plugin][63]                        | [GNU Lesser General Public License 3.0][64]    |
-| [Apache Maven Clean Plugin][65]                         | [Apache License, Version 2.0][4]               |
-| [Apache Maven Deploy Plugin][66]                        | [Apache-2.0][4]                                |
-| [Apache Maven Install Plugin][67]                       | [Apache License, Version 2.0][4]               |
-| [Apache Maven Resources Plugin][68]                     | [Apache License, Version 2.0][4]               |
-| [Apache Maven Site Plugin][69]                          | [Apache License, Version 2.0][4]               |
+| [SonarQube Scanner for Maven][38]                       | [GNU LGPL 3][39]                               |
+| [Apache Maven Toolchains Plugin][40]                    | [Apache-2.0][4]                                |
+| [Apache Maven Compiler Plugin][41]                      | [Apache-2.0][4]                                |
+| [Apache Maven Enforcer Plugin][42]                      | [Apache-2.0][4]                                |
+| [Maven Flatten Plugin][43]                              | [Apache Software License][4]                   |
+| [org.sonatype.ossindex.maven:ossindex-maven-plugin][44] | [ASL2][26]                                     |
+| [Maven Surefire Plugin][45]                             | [Apache-2.0][4]                                |
+| [Versions Maven Plugin][46]                             | [Apache License, Version 2.0][4]               |
+| [duplicate-finder-maven-plugin Maven Mojo][47]          | [Apache License 2.0][48]                       |
+| [Apache Maven Artifact Plugin][49]                      | [Apache-2.0][4]                                |
+| [Apache Maven Assembly Plugin][50]                      | [Apache-2.0][4]                                |
+| [Apache Maven JAR Plugin][51]                           | [Apache-2.0][4]                                |
+| [OpenFastTrace Maven Plugin][52]                        | [GNU General Public License v3.0][53]          |
+| [Project Keeper Maven plugin][54]                       | [The MIT License][55]                          |
+| [Artifact reference checker and unifier][56]            | [MIT License][57]                              |
+| [spdx-maven-plugin Maven Plugin][58]                    | [The Apache Software License, Version 2.0][26] |
+| [Apache Maven Dependency Plugin][59]                    | [Apache-2.0][4]                                |
+| [Maven Failsafe Plugin][60]                             | [Apache-2.0][4]                                |
+| [JaCoCo :: Maven Plugin][61]                            | [EPL-2.0][62]                                  |
+| [error-code-crawler-maven-plugin][63]                   | [MIT License][64]                              |
+| [Git Commit Id Maven Plugin][65]                        | [GNU Lesser General Public License 3.0][66]    |
+| [Apache Maven Clean Plugin][67]                         | [Apache License, Version 2.0][4]               |
+| [Apache Maven Deploy Plugin][68]                        | [Apache-2.0][4]                                |
+| [Apache Maven Install Plugin][69]                       | [Apache License, Version 2.0][4]               |
+| [Apache Maven Resources Plugin][70]                     | [Apache License, Version 2.0][4]               |
+| [Apache Maven Site Plugin][71]                          | [Apache License, Version 2.0][4]               |
 
 [0]: https://www.atlassian.com/public-pom/jira-rest-java-client-parent/jira-rest-java-client-core/
 [1]: https://www.apache.org/licenses/LICENSE-2.0
@@ -83,52 +84,54 @@
 [18]: https://projects.eclipse.org/license/epl-2.0
 [19]: https://projects.eclipse.org/license/secondary-gpl-2.0-cp
 [20]: https://maven.apache.org/ref/3.9.16/maven-model/
-[21]: https://github.com/commonmark/commonmark-java/commonmark
-[22]: https://opensource.org/licenses/BSD-2-Clause
-[23]: https://bitbucket.org/snakeyaml/snakeyaml
-[24]: http://www.apache.org/licenses/LICENSE-2.0.txt
-[25]: https://github.com/jline/jline3/jansi
-[26]: https://opensource.org/licenses/BSD-3-Clause
-[27]: https://junit.org/
-[28]: https://www.eclipse.org/legal/epl-v20.html
-[29]: https://github.com/mockito/mockito
-[30]: https://opensource.org/licenses/MIT
-[31]: http://hamcrest.org/JavaHamcrest/
-[32]: https://raw.githubusercontent.com/hamcrest/JavaHamcrest/master/LICENSE
-[33]: https://github.com/exasol/maven-project-version-getter/
-[34]: https://github.com/exasol/maven-project-version-getter/blob/main/LICENSE
-[35]: https://www.jqno.nl/equalsverifier
-[36]: https://docs.sonarsource.com/sonarqube-server/latest/extension-guide/developing-a-plugin/plugin-basics/sonar-scanner-maven/sonar-maven-plugin/
-[37]: http://www.gnu.org/licenses/lgpl.txt
-[38]: https://maven.apache.org/plugins/maven-toolchains-plugin/
-[39]: https://maven.apache.org/plugins/maven-compiler-plugin/
-[40]: https://maven.apache.org/enforcer/maven-enforcer-plugin/
-[41]: https://www.mojohaus.org/flatten-maven-plugin/
-[42]: https://sonatype.github.io/ossindex-maven/maven-plugin/
-[43]: https://maven.apache.org/surefire/maven-surefire-plugin/
-[44]: https://www.mojohaus.org/versions/versions-maven-plugin/
-[45]: https://basepom.github.io/duplicate-finder-maven-plugin
-[46]: http://www.apache.org/licenses/LICENSE-2.0.html
-[47]: https://maven.apache.org/plugins/maven-artifact-plugin/
-[48]: https://maven.apache.org/plugins/maven-assembly-plugin/
-[49]: https://maven.apache.org/plugins/maven-jar-plugin/
-[50]: https://github.com/itsallcode/openfasttrace-maven-plugin
-[51]: https://www.gnu.org/licenses/gpl-3.0.html
-[52]: https://github.com/exasol/project-keeper/
-[53]: https://github.com/exasol/project-keeper/blob/main/LICENSE
-[54]: https://github.com/exasol/artifact-reference-checker-maven-plugin/
-[55]: https://github.com/exasol/artifact-reference-checker-maven-plugin/blob/main/LICENSE
-[56]: https://github.com/spdx/spdx-maven-plugin
-[57]: https://maven.apache.org/plugins/maven-dependency-plugin/
-[58]: https://maven.apache.org/surefire/maven-failsafe-plugin/
-[59]: https://www.jacoco.org/jacoco/trunk/doc/maven.html
-[60]: https://www.eclipse.org/legal/epl-2.0/
-[61]: https://github.com/exasol/error-code-crawler-maven-plugin/
-[62]: https://github.com/exasol/error-code-crawler-maven-plugin/blob/main/LICENSE
-[63]: https://github.com/git-commit-id/git-commit-id-maven-plugin
-[64]: http://www.gnu.org/licenses/lgpl-3.0.txt
-[65]: https://maven.apache.org/plugins/maven-clean-plugin/
-[66]: https://maven.apache.org/plugins/maven-deploy-plugin/
-[67]: https://maven.apache.org/plugins/maven-install-plugin/
-[68]: https://maven.apache.org/plugins/maven-resources-plugin/
-[69]: https://maven.apache.org/plugins/maven-site-plugin/
+[21]: https://github.com/exasol/error-reporting-java/
+[22]: https://github.com/exasol/error-reporting-java/blob/main/LICENSE
+[23]: https://github.com/commonmark/commonmark-java/commonmark
+[24]: https://opensource.org/licenses/BSD-2-Clause
+[25]: https://bitbucket.org/snakeyaml/snakeyaml
+[26]: http://www.apache.org/licenses/LICENSE-2.0.txt
+[27]: https://github.com/jline/jline3/jansi
+[28]: https://opensource.org/licenses/BSD-3-Clause
+[29]: https://junit.org/
+[30]: https://www.eclipse.org/legal/epl-v20.html
+[31]: https://github.com/mockito/mockito
+[32]: https://opensource.org/licenses/MIT
+[33]: http://hamcrest.org/JavaHamcrest/
+[34]: https://raw.githubusercontent.com/hamcrest/JavaHamcrest/master/LICENSE
+[35]: https://github.com/exasol/maven-project-version-getter/
+[36]: https://github.com/exasol/maven-project-version-getter/blob/main/LICENSE
+[37]: https://www.jqno.nl/equalsverifier
+[38]: https://docs.sonarsource.com/sonarqube-server/latest/extension-guide/developing-a-plugin/plugin-basics/sonar-scanner-maven/sonar-maven-plugin/
+[39]: http://www.gnu.org/licenses/lgpl.txt
+[40]: https://maven.apache.org/plugins/maven-toolchains-plugin/
+[41]: https://maven.apache.org/plugins/maven-compiler-plugin/
+[42]: https://maven.apache.org/enforcer/maven-enforcer-plugin/
+[43]: https://www.mojohaus.org/flatten-maven-plugin/
+[44]: https://sonatype.github.io/ossindex-maven/maven-plugin/
+[45]: https://maven.apache.org/surefire/maven-surefire-plugin/
+[46]: https://www.mojohaus.org/versions/versions-maven-plugin/
+[47]: https://basepom.github.io/duplicate-finder-maven-plugin
+[48]: http://www.apache.org/licenses/LICENSE-2.0.html
+[49]: https://maven.apache.org/plugins/maven-artifact-plugin/
+[50]: https://maven.apache.org/plugins/maven-assembly-plugin/
+[51]: https://maven.apache.org/plugins/maven-jar-plugin/
+[52]: https://github.com/itsallcode/openfasttrace-maven-plugin
+[53]: https://www.gnu.org/licenses/gpl-3.0.html
+[54]: https://github.com/exasol/project-keeper/
+[55]: https://github.com/exasol/project-keeper/blob/main/LICENSE
+[56]: https://github.com/exasol/artifact-reference-checker-maven-plugin/
+[57]: https://github.com/exasol/artifact-reference-checker-maven-plugin/blob/main/LICENSE
+[58]: https://github.com/spdx/spdx-maven-plugin
+[59]: https://maven.apache.org/plugins/maven-dependency-plugin/
+[60]: https://maven.apache.org/surefire/maven-failsafe-plugin/
+[61]: https://www.jacoco.org/jacoco/trunk/doc/maven.html
+[62]: https://www.eclipse.org/legal/epl-2.0/
+[63]: https://github.com/exasol/error-code-crawler-maven-plugin/
+[64]: https://github.com/exasol/error-code-crawler-maven-plugin/blob/main/LICENSE
+[65]: https://github.com/git-commit-id/git-commit-id-maven-plugin
+[66]: http://www.gnu.org/licenses/lgpl-3.0.txt
+[67]: https://maven.apache.org/plugins/maven-clean-plugin/
+[68]: https://maven.apache.org/plugins/maven-deploy-plugin/
+[69]: https://maven.apache.org/plugins/maven-install-plugin/
+[70]: https://maven.apache.org/plugins/maven-resources-plugin/
+[71]: https://maven.apache.org/plugins/maven-site-plugin/

--- a/dependencies.md
+++ b/dependencies.md
@@ -6,127 +6,131 @@
 | Dependency                                  | License                                                                                                        |
 | ------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
 | [JIRA REST Java Client - Implementation][0] | [Apache License, Version 2.0][1]                                                                               |
-| [Functional Extensions][2]                  | [Apache License 2.0][1]                                                                                        |
-| [GitHub API for Java][3]                    | [The MIT license][4]                                                                                           |
-| [jackson-databind][5]                       | [The Apache Software License, Version 2.0][6]                                                                  |
-| [JGit - Core][7]                            | [BSD-3-Clause][8]                                                                                              |
-| [SLF4J Simple Binding][9]                   | [MIT License][10]                                                                                              |
-| [Apache Commons CLI][11]                    | [Apache-2.0][6]                                                                                                |
-| [Jakarta JSON Processing API][12]           | [Eclipse Public License 2.0][13]; [GNU General Public License, version 2 with the GNU Classpath Exception][14] |
-| [Yasson][15]                                | [Eclipse Public License v. 2.0][16]; [Eclipse Distribution License v. 1.0][17]                                 |
-| [Maven Model][18]                           | [Apache-2.0][6]                                                                                                |
-| [error-reporting-java][19]                  | [MIT License][20]                                                                                              |
-| [commonmark-java core][21]                  | [BSD-2-Clause][22]                                                                                             |
-| [SnakeYAML][23]                             | [Apache License, Version 2.0][24]                                                                              |
-| [Jansi][25]                                 | [Apache License, Version 2.0][24]                                                                              |
+| [Spring Beans][2]                           | [Apache License, Version 2.0][1]                                                                               |
+| [Apache Commons Lang][3]                    | [Apache-2.0][4]                                                                                                |
+| [Functional Extensions][5]                  | [Apache License 2.0][1]                                                                                        |
+| [GitHub API for Java][6]                    | [The MIT license][7]                                                                                           |
+| [jackson-databind][8]                       | [The Apache Software License, Version 2.0][4]                                                                  |
+| [JGit - Core][9]                            | [BSD-3-Clause][10]                                                                                             |
+| [SLF4J Simple Binding][11]                  | [MIT License][12]                                                                                              |
+| [Apache Commons CLI][13]                    | [Apache-2.0][4]                                                                                                |
+| [Yasson][14]                                | [Eclipse Public License v. 2.0][15]; [Eclipse Distribution License v. 1.0][16]                                 |
+| [Eclipse Parsson][17]                       | [Eclipse Public License 2.0][18]; [GNU General Public License, version 2 with the GNU Classpath Exception][19] |
+| [Maven Model][20]                           | [Apache-2.0][4]                                                                                                |
+| [error-reporting-java][21]                  | [MIT License][22]                                                                                              |
+| [commonmark-java core][23]                  | [BSD-2-Clause][24]                                                                                             |
+| [SnakeYAML][25]                             | [Apache License, Version 2.0][26]                                                                              |
+| [Jansi][27]                                 | [Apache License, Version 2.0][26]                                                                              |
 
 ## Test Dependencies
 
 | Dependency                                 | License                           |
 | ------------------------------------------ | --------------------------------- |
-| [JUnit Jupiter (Aggregator)][26]           | [Eclipse Public License v2.0][27] |
-| [mockito-junit-jupiter][28]                | [MIT][29]                         |
-| [Hamcrest][30]                             | [BSD-3-Clause][31]                |
-| [Maven Project Version Getter][32]         | [MIT License][33]                 |
-| [EqualsVerifier \| release normal jar][34] | [Apache License, Version 2.0][6]  |
+| [JUnit Jupiter (Aggregator)][28]           | [Eclipse Public License v2.0][29] |
+| [mockito-junit-jupiter][30]                | [MIT][31]                         |
+| [Hamcrest][32]                             | [BSD-3-Clause][33]                |
+| [Maven Project Version Getter][34]         | [MIT License][35]                 |
+| [EqualsVerifier \| release normal jar][36] | [Apache License, Version 2.0][4]  |
 
 ## Plugin Dependencies
 
 | Dependency                                              | License                                        |
 | ------------------------------------------------------- | ---------------------------------------------- |
-| [SonarQube Scanner for Maven][35]                       | [GNU LGPL 3][36]                               |
-| [Apache Maven Toolchains Plugin][37]                    | [Apache-2.0][6]                                |
-| [Apache Maven Compiler Plugin][38]                      | [Apache-2.0][6]                                |
-| [Apache Maven Enforcer Plugin][39]                      | [Apache-2.0][6]                                |
-| [Maven Flatten Plugin][40]                              | [Apache Software License][6]                   |
-| [org.sonatype.ossindex.maven:ossindex-maven-plugin][41] | [ASL2][24]                                     |
-| [Maven Surefire Plugin][42]                             | [Apache-2.0][6]                                |
-| [Versions Maven Plugin][43]                             | [Apache License, Version 2.0][6]               |
-| [duplicate-finder-maven-plugin Maven Mojo][44]          | [Apache License 2.0][45]                       |
-| [Apache Maven Artifact Plugin][46]                      | [Apache-2.0][6]                                |
-| [Apache Maven Assembly Plugin][47]                      | [Apache-2.0][6]                                |
-| [Apache Maven JAR Plugin][48]                           | [Apache-2.0][6]                                |
-| [OpenFastTrace Maven Plugin][49]                        | [GNU General Public License v3.0][50]          |
-| [Project Keeper Maven plugin][51]                       | [The MIT License][52]                          |
-| [Artifact reference checker and unifier][53]            | [MIT License][54]                              |
-| [spdx-maven-plugin Maven Plugin][55]                    | [The Apache Software License, Version 2.0][24] |
-| [Apache Maven Dependency Plugin][56]                    | [Apache-2.0][6]                                |
-| [Maven Failsafe Plugin][57]                             | [Apache-2.0][6]                                |
-| [JaCoCo :: Maven Plugin][58]                            | [EPL-2.0][59]                                  |
-| [error-code-crawler-maven-plugin][60]                   | [MIT License][61]                              |
-| [Git Commit Id Maven Plugin][62]                        | [GNU Lesser General Public License 3.0][63]    |
-| [Apache Maven Clean Plugin][64]                         | [Apache License, Version 2.0][6]               |
-| [Apache Maven Deploy Plugin][65]                        | [Apache-2.0][6]                                |
-| [Apache Maven Install Plugin][66]                       | [Apache License, Version 2.0][6]               |
-| [Apache Maven Resources Plugin][67]                     | [Apache License, Version 2.0][6]               |
-| [Apache Maven Site Plugin][68]                          | [Apache License, Version 2.0][6]               |
+| [SonarQube Scanner for Maven][37]                       | [GNU LGPL 3][38]                               |
+| [Apache Maven Toolchains Plugin][39]                    | [Apache-2.0][4]                                |
+| [Apache Maven Compiler Plugin][40]                      | [Apache-2.0][4]                                |
+| [Apache Maven Enforcer Plugin][41]                      | [Apache-2.0][4]                                |
+| [Maven Flatten Plugin][42]                              | [Apache Software License][4]                   |
+| [org.sonatype.ossindex.maven:ossindex-maven-plugin][43] | [ASL2][26]                                     |
+| [Maven Surefire Plugin][44]                             | [Apache-2.0][4]                                |
+| [Versions Maven Plugin][45]                             | [Apache License, Version 2.0][4]               |
+| [duplicate-finder-maven-plugin Maven Mojo][46]          | [Apache License 2.0][47]                       |
+| [Apache Maven Artifact Plugin][48]                      | [Apache-2.0][4]                                |
+| [Apache Maven Assembly Plugin][49]                      | [Apache-2.0][4]                                |
+| [Apache Maven JAR Plugin][50]                           | [Apache-2.0][4]                                |
+| [OpenFastTrace Maven Plugin][51]                        | [GNU General Public License v3.0][52]          |
+| [Project Keeper Maven plugin][53]                       | [The MIT License][54]                          |
+| [Artifact reference checker and unifier][55]            | [MIT License][56]                              |
+| [spdx-maven-plugin Maven Plugin][57]                    | [The Apache Software License, Version 2.0][26] |
+| [Apache Maven Dependency Plugin][58]                    | [Apache-2.0][4]                                |
+| [Maven Failsafe Plugin][59]                             | [Apache-2.0][4]                                |
+| [JaCoCo :: Maven Plugin][60]                            | [EPL-2.0][61]                                  |
+| [error-code-crawler-maven-plugin][62]                   | [MIT License][63]                              |
+| [Git Commit Id Maven Plugin][64]                        | [GNU Lesser General Public License 3.0][65]    |
+| [Apache Maven Clean Plugin][66]                         | [Apache License, Version 2.0][4]               |
+| [Apache Maven Deploy Plugin][67]                        | [Apache-2.0][4]                                |
+| [Apache Maven Install Plugin][68]                       | [Apache License, Version 2.0][4]               |
+| [Apache Maven Resources Plugin][69]                     | [Apache License, Version 2.0][4]               |
+| [Apache Maven Site Plugin][70]                          | [Apache License, Version 2.0][4]               |
 
 [0]: https://www.atlassian.com/public-pom/jira-rest-java-client-parent/jira-rest-java-client-core/
 [1]: https://www.apache.org/licenses/LICENSE-2.0
-[2]: https://www.atlassian.com/central-pom/fugue-parent/fugue/
-[3]: https://hub4j.github.io/github-api/
-[4]: https://www.opensource.org/licenses/mit-license.php
-[5]: https://github.com/FasterXML/jackson
-[6]: https://www.apache.org/licenses/LICENSE-2.0.txt
-[7]: https://www.eclipse.org/jgit/
-[8]: https://www.eclipse.org/org/documents/edl-v10.php
-[9]: http://www.slf4j.org
-[10]: http://www.opensource.org/licenses/mit-license.php
-[11]: https://commons.apache.org/proper/commons-cli/
-[12]: https://github.com/eclipse-ee4j/jsonp
-[13]: https://projects.eclipse.org/license/epl-2.0
-[14]: https://projects.eclipse.org/license/secondary-gpl-2.0-cp
-[15]: https://projects.eclipse.org/projects/ee4j.yasson
-[16]: http://www.eclipse.org/legal/epl-v20.html
-[17]: http://www.eclipse.org/org/documents/edl-v10.php
-[18]: https://maven.apache.org/ref/3.9.16/maven-model/
-[19]: https://github.com/exasol/error-reporting-java/
-[20]: https://github.com/exasol/error-reporting-java/blob/main/LICENSE
-[21]: https://github.com/commonmark/commonmark-java/commonmark
-[22]: https://opensource.org/licenses/BSD-2-Clause
-[23]: https://bitbucket.org/snakeyaml/snakeyaml
-[24]: http://www.apache.org/licenses/LICENSE-2.0.txt
-[25]: http://fusesource.github.io/jansi
-[26]: https://junit.org/
-[27]: https://www.eclipse.org/legal/epl-v20.html
-[28]: https://github.com/mockito/mockito
-[29]: https://opensource.org/licenses/MIT
-[30]: http://hamcrest.org/JavaHamcrest/
-[31]: https://raw.githubusercontent.com/hamcrest/JavaHamcrest/master/LICENSE
-[32]: https://github.com/exasol/maven-project-version-getter/
-[33]: https://github.com/exasol/maven-project-version-getter/blob/main/LICENSE
-[34]: https://www.jqno.nl/equalsverifier
-[35]: https://docs.sonarsource.com/sonarqube-server/latest/extension-guide/developing-a-plugin/plugin-basics/sonar-scanner-maven/sonar-maven-plugin/
-[36]: http://www.gnu.org/licenses/lgpl.txt
-[37]: https://maven.apache.org/plugins/maven-toolchains-plugin/
-[38]: https://maven.apache.org/plugins/maven-compiler-plugin/
-[39]: https://maven.apache.org/enforcer/maven-enforcer-plugin/
-[40]: https://www.mojohaus.org/flatten-maven-plugin/
-[41]: https://sonatype.github.io/ossindex-maven/maven-plugin/
-[42]: https://maven.apache.org/surefire/maven-surefire-plugin/
-[43]: https://www.mojohaus.org/versions/versions-maven-plugin/
-[44]: https://basepom.github.io/duplicate-finder-maven-plugin
-[45]: http://www.apache.org/licenses/LICENSE-2.0.html
-[46]: https://maven.apache.org/plugins/maven-artifact-plugin/
-[47]: https://maven.apache.org/plugins/maven-assembly-plugin/
-[48]: https://maven.apache.org/plugins/maven-jar-plugin/
-[49]: https://github.com/itsallcode/openfasttrace-maven-plugin
-[50]: https://www.gnu.org/licenses/gpl-3.0.html
-[51]: https://github.com/exasol/project-keeper/
-[52]: https://github.com/exasol/project-keeper/blob/main/LICENSE
-[53]: https://github.com/exasol/artifact-reference-checker-maven-plugin/
-[54]: https://github.com/exasol/artifact-reference-checker-maven-plugin/blob/main/LICENSE
-[55]: https://github.com/spdx/spdx-maven-plugin
-[56]: https://maven.apache.org/plugins/maven-dependency-plugin/
-[57]: https://maven.apache.org/surefire/maven-failsafe-plugin/
-[58]: https://www.jacoco.org/jacoco/trunk/doc/maven.html
-[59]: https://www.eclipse.org/legal/epl-2.0/
-[60]: https://github.com/exasol/error-code-crawler-maven-plugin/
-[61]: https://github.com/exasol/error-code-crawler-maven-plugin/blob/main/LICENSE
-[62]: https://github.com/git-commit-id/git-commit-id-maven-plugin
-[63]: http://www.gnu.org/licenses/lgpl-3.0.txt
-[64]: https://maven.apache.org/plugins/maven-clean-plugin/
-[65]: https://maven.apache.org/plugins/maven-deploy-plugin/
-[66]: https://maven.apache.org/plugins/maven-install-plugin/
-[67]: https://maven.apache.org/plugins/maven-resources-plugin/
-[68]: https://maven.apache.org/plugins/maven-site-plugin/
+[2]: https://github.com/spring-projects/spring-framework
+[3]: https://commons.apache.org/proper/commons-lang/
+[4]: https://www.apache.org/licenses/LICENSE-2.0.txt
+[5]: https://www.atlassian.com/central-pom/fugue-parent/fugue/
+[6]: https://hub4j.github.io/github-api/
+[7]: https://www.opensource.org/licenses/mit-license.php
+[8]: https://github.com/FasterXML/jackson
+[9]: https://www.eclipse.org/jgit/
+[10]: https://www.eclipse.org/org/documents/edl-v10.php
+[11]: http://www.slf4j.org
+[12]: http://www.opensource.org/licenses/mit-license.php
+[13]: https://commons.apache.org/proper/commons-cli/
+[14]: https://projects.eclipse.org/projects/ee4j.yasson
+[15]: http://www.eclipse.org/legal/epl-v20.html
+[16]: http://www.eclipse.org/org/documents/edl-v10.php
+[17]: https://github.com/eclipse-ee4j/parsson
+[18]: https://projects.eclipse.org/license/epl-2.0
+[19]: https://projects.eclipse.org/license/secondary-gpl-2.0-cp
+[20]: https://maven.apache.org/ref/3.9.16/maven-model/
+[21]: https://github.com/exasol/error-reporting-java/
+[22]: https://github.com/exasol/error-reporting-java/blob/main/LICENSE
+[23]: https://github.com/commonmark/commonmark-java/commonmark
+[24]: https://opensource.org/licenses/BSD-2-Clause
+[25]: https://bitbucket.org/snakeyaml/snakeyaml
+[26]: http://www.apache.org/licenses/LICENSE-2.0.txt
+[27]: http://fusesource.github.io/jansi
+[28]: https://junit.org/
+[29]: https://www.eclipse.org/legal/epl-v20.html
+[30]: https://github.com/mockito/mockito
+[31]: https://opensource.org/licenses/MIT
+[32]: http://hamcrest.org/JavaHamcrest/
+[33]: https://raw.githubusercontent.com/hamcrest/JavaHamcrest/master/LICENSE
+[34]: https://github.com/exasol/maven-project-version-getter/
+[35]: https://github.com/exasol/maven-project-version-getter/blob/main/LICENSE
+[36]: https://www.jqno.nl/equalsverifier
+[37]: https://docs.sonarsource.com/sonarqube-server/latest/extension-guide/developing-a-plugin/plugin-basics/sonar-scanner-maven/sonar-maven-plugin/
+[38]: http://www.gnu.org/licenses/lgpl.txt
+[39]: https://maven.apache.org/plugins/maven-toolchains-plugin/
+[40]: https://maven.apache.org/plugins/maven-compiler-plugin/
+[41]: https://maven.apache.org/enforcer/maven-enforcer-plugin/
+[42]: https://www.mojohaus.org/flatten-maven-plugin/
+[43]: https://sonatype.github.io/ossindex-maven/maven-plugin/
+[44]: https://maven.apache.org/surefire/maven-surefire-plugin/
+[45]: https://www.mojohaus.org/versions/versions-maven-plugin/
+[46]: https://basepom.github.io/duplicate-finder-maven-plugin
+[47]: http://www.apache.org/licenses/LICENSE-2.0.html
+[48]: https://maven.apache.org/plugins/maven-artifact-plugin/
+[49]: https://maven.apache.org/plugins/maven-assembly-plugin/
+[50]: https://maven.apache.org/plugins/maven-jar-plugin/
+[51]: https://github.com/itsallcode/openfasttrace-maven-plugin
+[52]: https://www.gnu.org/licenses/gpl-3.0.html
+[53]: https://github.com/exasol/project-keeper/
+[54]: https://github.com/exasol/project-keeper/blob/main/LICENSE
+[55]: https://github.com/exasol/artifact-reference-checker-maven-plugin/
+[56]: https://github.com/exasol/artifact-reference-checker-maven-plugin/blob/main/LICENSE
+[57]: https://github.com/spdx/spdx-maven-plugin
+[58]: https://maven.apache.org/plugins/maven-dependency-plugin/
+[59]: https://maven.apache.org/surefire/maven-failsafe-plugin/
+[60]: https://www.jacoco.org/jacoco/trunk/doc/maven.html
+[61]: https://www.eclipse.org/legal/epl-2.0/
+[62]: https://github.com/exasol/error-code-crawler-maven-plugin/
+[63]: https://github.com/exasol/error-code-crawler-maven-plugin/blob/main/LICENSE
+[64]: https://github.com/git-commit-id/git-commit-id-maven-plugin
+[65]: http://www.gnu.org/licenses/lgpl-3.0.txt
+[66]: https://maven.apache.org/plugins/maven-clean-plugin/
+[67]: https://maven.apache.org/plugins/maven-deploy-plugin/
+[68]: https://maven.apache.org/plugins/maven-install-plugin/
+[69]: https://maven.apache.org/plugins/maven-resources-plugin/
+[70]: https://maven.apache.org/plugins/maven-site-plugin/

--- a/dependencies.md
+++ b/dependencies.md
@@ -8,132 +8,125 @@
 | [JIRA REST Java Client - Implementation][0] | [Apache License, Version 2.0][1]                                                                               |
 | [Functional Extensions][2]                  | [Apache License 2.0][1]                                                                                        |
 | [GitHub API for Java][3]                    | [The MIT license][4]                                                                                           |
-| [SpotBugs Annotations][5]                   | [GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1][6]                                                            |
-| [Bridge method injection annotations][7]    | [MIT License][8]                                                                                               |
-| [jackson-databind][9]                       | [The Apache Software License, Version 2.0][10]                                                                 |
-| [JGit - Core][11]                           | [BSD-3-Clause][12]                                                                                             |
-| [SLF4J Simple Binding][13]                  | [MIT License][14]                                                                                              |
-| [Apache Commons CLI][15]                    | [Apache-2.0][10]                                                                                               |
-| [Jakarta JSON Processing API][16]           | [Eclipse Public License 2.0][17]; [GNU General Public License, version 2 with the GNU Classpath Exception][18] |
-| [Yasson][19]                                | [Eclipse Public License v. 2.0][20]; [Eclipse Distribution License v. 1.0][21]                                 |
-| [Eclipse Parsson][22]                       | [Eclipse Public License 2.0][17]; [GNU General Public License, version 2 with the GNU Classpath Exception][18] |
-| [Maven Model][23]                           | [Apache-2.0][10]                                                                                               |
-| [error-reporting-java][24]                  | [MIT License][25]                                                                                              |
-| [commonmark-java core][26]                  | [BSD-2-Clause][27]                                                                                             |
-| [SnakeYAML][28]                             | [Apache License, Version 2.0][29]                                                                              |
-| [Jansi][30]                                 | [Apache License, Version 2.0][29]                                                                              |
+| [jackson-databind][5]                       | [The Apache Software License, Version 2.0][6]                                                                  |
+| [JGit - Core][7]                            | [BSD-3-Clause][8]                                                                                              |
+| [SLF4J Simple Binding][9]                   | [MIT License][10]                                                                                              |
+| [Apache Commons CLI][11]                    | [Apache-2.0][6]                                                                                                |
+| [Jakarta JSON Processing API][12]           | [Eclipse Public License 2.0][13]; [GNU General Public License, version 2 with the GNU Classpath Exception][14] |
+| [Yasson][15]                                | [Eclipse Public License v. 2.0][16]; [Eclipse Distribution License v. 1.0][17]                                 |
+| [Maven Model][18]                           | [Apache-2.0][6]                                                                                                |
+| [error-reporting-java][19]                  | [MIT License][20]                                                                                              |
+| [commonmark-java core][21]                  | [BSD-2-Clause][22]                                                                                             |
+| [SnakeYAML][23]                             | [Apache License, Version 2.0][24]                                                                              |
+| [Jansi][25]                                 | [Apache License, Version 2.0][24]                                                                              |
 
 ## Test Dependencies
 
 | Dependency                                 | License                           |
 | ------------------------------------------ | --------------------------------- |
-| [JUnit Jupiter (Aggregator)][31]           | [Eclipse Public License v2.0][32] |
-| [mockito-junit-jupiter][33]                | [MIT][8]                          |
-| [Hamcrest][34]                             | [BSD-3-Clause][35]                |
-| [Maven Project Version Getter][36]         | [MIT License][37]                 |
-| [EqualsVerifier \| release normal jar][38] | [Apache License, Version 2.0][10] |
+| [JUnit Jupiter (Aggregator)][26]           | [Eclipse Public License v2.0][27] |
+| [mockito-junit-jupiter][28]                | [MIT][29]                         |
+| [Hamcrest][30]                             | [BSD-3-Clause][31]                |
+| [Maven Project Version Getter][32]         | [MIT License][33]                 |
+| [EqualsVerifier \| release normal jar][34] | [Apache License, Version 2.0][6]  |
 
 ## Plugin Dependencies
 
 | Dependency                                              | License                                        |
 | ------------------------------------------------------- | ---------------------------------------------- |
-| [SonarQube Scanner for Maven][39]                       | [GNU LGPL 3][40]                               |
-| [Apache Maven Toolchains Plugin][41]                    | [Apache-2.0][10]                               |
-| [Apache Maven Compiler Plugin][42]                      | [Apache-2.0][10]                               |
-| [Apache Maven Enforcer Plugin][43]                      | [Apache-2.0][10]                               |
-| [Maven Flatten Plugin][44]                              | [Apache Software License][10]                  |
-| [org.sonatype.ossindex.maven:ossindex-maven-plugin][45] | [ASL2][29]                                     |
-| [Maven Surefire Plugin][46]                             | [Apache-2.0][10]                               |
-| [Versions Maven Plugin][47]                             | [Apache License, Version 2.0][10]              |
-| [duplicate-finder-maven-plugin Maven Mojo][48]          | [Apache License 2.0][49]                       |
-| [Apache Maven Artifact Plugin][50]                      | [Apache-2.0][10]                               |
-| [Apache Maven Assembly Plugin][51]                      | [Apache-2.0][10]                               |
-| [Apache Maven JAR Plugin][52]                           | [Apache-2.0][10]                               |
-| [OpenFastTrace Maven Plugin][53]                        | [GNU General Public License v3.0][54]          |
-| [Project Keeper Maven plugin][55]                       | [The MIT License][56]                          |
-| [Artifact reference checker and unifier][57]            | [MIT License][58]                              |
-| [spdx-maven-plugin Maven Plugin][59]                    | [The Apache Software License, Version 2.0][29] |
-| [Apache Maven Dependency Plugin][60]                    | [Apache-2.0][10]                               |
-| [Maven Failsafe Plugin][61]                             | [Apache-2.0][10]                               |
-| [JaCoCo :: Maven Plugin][62]                            | [EPL-2.0][63]                                  |
-| [error-code-crawler-maven-plugin][64]                   | [MIT License][65]                              |
-| [Git Commit Id Maven Plugin][66]                        | [GNU Lesser General Public License 3.0][67]    |
-| [Apache Maven Clean Plugin][68]                         | [Apache License, Version 2.0][10]              |
-| [Apache Maven Deploy Plugin][69]                        | [Apache-2.0][10]                               |
-| [Apache Maven Install Plugin][70]                       | [Apache License, Version 2.0][10]              |
-| [Apache Maven Resources Plugin][71]                     | [Apache License, Version 2.0][10]              |
-| [Apache Maven Site Plugin][72]                          | [Apache License, Version 2.0][10]              |
+| [SonarQube Scanner for Maven][35]                       | [GNU LGPL 3][36]                               |
+| [Apache Maven Toolchains Plugin][37]                    | [Apache-2.0][6]                                |
+| [Apache Maven Compiler Plugin][38]                      | [Apache-2.0][6]                                |
+| [Apache Maven Enforcer Plugin][39]                      | [Apache-2.0][6]                                |
+| [Maven Flatten Plugin][40]                              | [Apache Software License][6]                   |
+| [org.sonatype.ossindex.maven:ossindex-maven-plugin][41] | [ASL2][24]                                     |
+| [Maven Surefire Plugin][42]                             | [Apache-2.0][6]                                |
+| [Versions Maven Plugin][43]                             | [Apache License, Version 2.0][6]               |
+| [duplicate-finder-maven-plugin Maven Mojo][44]          | [Apache License 2.0][45]                       |
+| [Apache Maven Artifact Plugin][46]                      | [Apache-2.0][6]                                |
+| [Apache Maven Assembly Plugin][47]                      | [Apache-2.0][6]                                |
+| [Apache Maven JAR Plugin][48]                           | [Apache-2.0][6]                                |
+| [OpenFastTrace Maven Plugin][49]                        | [GNU General Public License v3.0][50]          |
+| [Project Keeper Maven plugin][51]                       | [The MIT License][52]                          |
+| [Artifact reference checker and unifier][53]            | [MIT License][54]                              |
+| [spdx-maven-plugin Maven Plugin][55]                    | [The Apache Software License, Version 2.0][24] |
+| [Apache Maven Dependency Plugin][56]                    | [Apache-2.0][6]                                |
+| [Maven Failsafe Plugin][57]                             | [Apache-2.0][6]                                |
+| [JaCoCo :: Maven Plugin][58]                            | [EPL-2.0][59]                                  |
+| [error-code-crawler-maven-plugin][60]                   | [MIT License][61]                              |
+| [Git Commit Id Maven Plugin][62]                        | [GNU Lesser General Public License 3.0][63]    |
+| [Apache Maven Clean Plugin][64]                         | [Apache License, Version 2.0][6]               |
+| [Apache Maven Deploy Plugin][65]                        | [Apache-2.0][6]                                |
+| [Apache Maven Install Plugin][66]                       | [Apache License, Version 2.0][6]               |
+| [Apache Maven Resources Plugin][67]                     | [Apache License, Version 2.0][6]               |
+| [Apache Maven Site Plugin][68]                          | [Apache License, Version 2.0][6]               |
 
 [0]: https://www.atlassian.com/public-pom/jira-rest-java-client-parent/jira-rest-java-client-core/
 [1]: https://www.apache.org/licenses/LICENSE-2.0
 [2]: https://www.atlassian.com/central-pom/fugue-parent/fugue/
-[3]: https://github-api.kohsuke.org/
+[3]: https://hub4j.github.io/github-api/
 [4]: https://www.opensource.org/licenses/mit-license.php
-[5]: https://spotbugs.github.io/
-[6]: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html
-[7]: https://github.com/jenkinsci/bridge-method-injector/bridge-method-annotation
-[8]: https://opensource.org/licenses/MIT
-[9]: https://github.com/FasterXML/jackson
-[10]: https://www.apache.org/licenses/LICENSE-2.0.txt
-[11]: https://www.eclipse.org/jgit/
-[12]: https://www.eclipse.org/org/documents/edl-v10.php
-[13]: http://www.slf4j.org
-[14]: http://www.opensource.org/licenses/mit-license.php
-[15]: https://commons.apache.org/proper/commons-cli/
-[16]: https://github.com/eclipse-ee4j/jsonp
-[17]: https://projects.eclipse.org/license/epl-2.0
-[18]: https://projects.eclipse.org/license/secondary-gpl-2.0-cp
-[19]: https://projects.eclipse.org/projects/ee4j.yasson
-[20]: http://www.eclipse.org/legal/epl-v20.html
-[21]: http://www.eclipse.org/org/documents/edl-v10.php
-[22]: https://github.com/eclipse-ee4j/parsson
-[23]: https://maven.apache.org/ref/3.9.16/maven-model/
-[24]: https://github.com/exasol/error-reporting-java/
-[25]: https://github.com/exasol/error-reporting-java/blob/main/LICENSE
-[26]: https://github.com/commonmark/commonmark-java/commonmark
-[27]: https://opensource.org/licenses/BSD-2-Clause
-[28]: https://bitbucket.org/snakeyaml/snakeyaml
-[29]: http://www.apache.org/licenses/LICENSE-2.0.txt
-[30]: http://fusesource.github.io/jansi
-[31]: https://junit.org/
-[32]: https://www.eclipse.org/legal/epl-v20.html
-[33]: https://github.com/mockito/mockito
-[34]: http://hamcrest.org/JavaHamcrest/
-[35]: https://raw.githubusercontent.com/hamcrest/JavaHamcrest/master/LICENSE
-[36]: https://github.com/exasol/maven-project-version-getter/
-[37]: https://github.com/exasol/maven-project-version-getter/blob/main/LICENSE
-[38]: https://www.jqno.nl/equalsverifier
-[39]: https://docs.sonarsource.com/sonarqube-server/latest/extension-guide/developing-a-plugin/plugin-basics/sonar-scanner-maven/sonar-maven-plugin/
-[40]: http://www.gnu.org/licenses/lgpl.txt
-[41]: https://maven.apache.org/plugins/maven-toolchains-plugin/
-[42]: https://maven.apache.org/plugins/maven-compiler-plugin/
-[43]: https://maven.apache.org/enforcer/maven-enforcer-plugin/
-[44]: https://www.mojohaus.org/flatten-maven-plugin/
-[45]: https://sonatype.github.io/ossindex-maven/maven-plugin/
-[46]: https://maven.apache.org/surefire/maven-surefire-plugin/
-[47]: https://www.mojohaus.org/versions/versions-maven-plugin/
-[48]: https://basepom.github.io/duplicate-finder-maven-plugin
-[49]: http://www.apache.org/licenses/LICENSE-2.0.html
-[50]: https://maven.apache.org/plugins/maven-artifact-plugin/
-[51]: https://maven.apache.org/plugins/maven-assembly-plugin/
-[52]: https://maven.apache.org/plugins/maven-jar-plugin/
-[53]: https://github.com/itsallcode/openfasttrace-maven-plugin
-[54]: https://www.gnu.org/licenses/gpl-3.0.html
-[55]: https://github.com/exasol/project-keeper/
-[56]: https://github.com/exasol/project-keeper/blob/main/LICENSE
-[57]: https://github.com/exasol/artifact-reference-checker-maven-plugin/
-[58]: https://github.com/exasol/artifact-reference-checker-maven-plugin/blob/main/LICENSE
-[59]: https://github.com/spdx/spdx-maven-plugin
-[60]: https://maven.apache.org/plugins/maven-dependency-plugin/
-[61]: https://maven.apache.org/surefire/maven-failsafe-plugin/
-[62]: https://www.jacoco.org/jacoco/trunk/doc/maven.html
-[63]: https://www.eclipse.org/legal/epl-2.0/
-[64]: https://github.com/exasol/error-code-crawler-maven-plugin/
-[65]: https://github.com/exasol/error-code-crawler-maven-plugin/blob/main/LICENSE
-[66]: https://github.com/git-commit-id/git-commit-id-maven-plugin
-[67]: http://www.gnu.org/licenses/lgpl-3.0.txt
-[68]: https://maven.apache.org/plugins/maven-clean-plugin/
-[69]: https://maven.apache.org/plugins/maven-deploy-plugin/
-[70]: https://maven.apache.org/plugins/maven-install-plugin/
-[71]: https://maven.apache.org/plugins/maven-resources-plugin/
-[72]: https://maven.apache.org/plugins/maven-site-plugin/
+[5]: https://github.com/FasterXML/jackson
+[6]: https://www.apache.org/licenses/LICENSE-2.0.txt
+[7]: https://www.eclipse.org/jgit/
+[8]: https://www.eclipse.org/org/documents/edl-v10.php
+[9]: http://www.slf4j.org
+[10]: http://www.opensource.org/licenses/mit-license.php
+[11]: https://commons.apache.org/proper/commons-cli/
+[12]: https://github.com/eclipse-ee4j/jsonp
+[13]: https://projects.eclipse.org/license/epl-2.0
+[14]: https://projects.eclipse.org/license/secondary-gpl-2.0-cp
+[15]: https://projects.eclipse.org/projects/ee4j.yasson
+[16]: http://www.eclipse.org/legal/epl-v20.html
+[17]: http://www.eclipse.org/org/documents/edl-v10.php
+[18]: https://maven.apache.org/ref/3.9.16/maven-model/
+[19]: https://github.com/exasol/error-reporting-java/
+[20]: https://github.com/exasol/error-reporting-java/blob/main/LICENSE
+[21]: https://github.com/commonmark/commonmark-java/commonmark
+[22]: https://opensource.org/licenses/BSD-2-Clause
+[23]: https://bitbucket.org/snakeyaml/snakeyaml
+[24]: http://www.apache.org/licenses/LICENSE-2.0.txt
+[25]: http://fusesource.github.io/jansi
+[26]: https://junit.org/
+[27]: https://www.eclipse.org/legal/epl-v20.html
+[28]: https://github.com/mockito/mockito
+[29]: https://opensource.org/licenses/MIT
+[30]: http://hamcrest.org/JavaHamcrest/
+[31]: https://raw.githubusercontent.com/hamcrest/JavaHamcrest/master/LICENSE
+[32]: https://github.com/exasol/maven-project-version-getter/
+[33]: https://github.com/exasol/maven-project-version-getter/blob/main/LICENSE
+[34]: https://www.jqno.nl/equalsverifier
+[35]: https://docs.sonarsource.com/sonarqube-server/latest/extension-guide/developing-a-plugin/plugin-basics/sonar-scanner-maven/sonar-maven-plugin/
+[36]: http://www.gnu.org/licenses/lgpl.txt
+[37]: https://maven.apache.org/plugins/maven-toolchains-plugin/
+[38]: https://maven.apache.org/plugins/maven-compiler-plugin/
+[39]: https://maven.apache.org/enforcer/maven-enforcer-plugin/
+[40]: https://www.mojohaus.org/flatten-maven-plugin/
+[41]: https://sonatype.github.io/ossindex-maven/maven-plugin/
+[42]: https://maven.apache.org/surefire/maven-surefire-plugin/
+[43]: https://www.mojohaus.org/versions/versions-maven-plugin/
+[44]: https://basepom.github.io/duplicate-finder-maven-plugin
+[45]: http://www.apache.org/licenses/LICENSE-2.0.html
+[46]: https://maven.apache.org/plugins/maven-artifact-plugin/
+[47]: https://maven.apache.org/plugins/maven-assembly-plugin/
+[48]: https://maven.apache.org/plugins/maven-jar-plugin/
+[49]: https://github.com/itsallcode/openfasttrace-maven-plugin
+[50]: https://www.gnu.org/licenses/gpl-3.0.html
+[51]: https://github.com/exasol/project-keeper/
+[52]: https://github.com/exasol/project-keeper/blob/main/LICENSE
+[53]: https://github.com/exasol/artifact-reference-checker-maven-plugin/
+[54]: https://github.com/exasol/artifact-reference-checker-maven-plugin/blob/main/LICENSE
+[55]: https://github.com/spdx/spdx-maven-plugin
+[56]: https://maven.apache.org/plugins/maven-dependency-plugin/
+[57]: https://maven.apache.org/surefire/maven-failsafe-plugin/
+[58]: https://www.jacoco.org/jacoco/trunk/doc/maven.html
+[59]: https://www.eclipse.org/legal/epl-2.0/
+[60]: https://github.com/exasol/error-code-crawler-maven-plugin/
+[61]: https://github.com/exasol/error-code-crawler-maven-plugin/blob/main/LICENSE
+[62]: https://github.com/git-commit-id/git-commit-id-maven-plugin
+[63]: http://www.gnu.org/licenses/lgpl-3.0.txt
+[64]: https://maven.apache.org/plugins/maven-clean-plugin/
+[65]: https://maven.apache.org/plugins/maven-deploy-plugin/
+[66]: https://maven.apache.org/plugins/maven-install-plugin/
+[67]: https://maven.apache.org/plugins/maven-resources-plugin/
+[68]: https://maven.apache.org/plugins/maven-site-plugin/

--- a/doc/changes/changelog.md
+++ b/doc/changes/changelog.md
@@ -1,5 +1,6 @@
 # Changes
 
+* [2.0.1](changes_2.0.1.md)
 * [2.0.0](changes_2.0.0.md)
 * [1.5.1](changes_1.5.1.md)
 * [1.5.0](changes_1.5.0.md)

--- a/doc/changes/changes_2.0.1.md
+++ b/doc/changes/changes_2.0.1.md
@@ -17,13 +17,15 @@ We also updated the GitHub API to 2.0-RC7 and adapted some code to match that. W
 * Updated `com.atlassian.jira:jira-rest-java-client-core:7.0.1` to `7.0.2`
 * Updated `com.fasterxml.jackson.core:jackson-databind:2.22.0` to `2.22.1`
 * Removed `com.infradna.tool:bridge-method-annotation:1.31`
+* Removed `jakarta.json:jakarta.json-api:2.1.3`
+* Added `org.apache.commons:commons-lang3:3.20.0`
 * Updated `org.commonmark:commonmark:0.28.0` to `0.29.0`
-* Removed `org.eclipse.parsson:parsson:1.1.9`
 * Updated `org.kohsuke:github-api:1.330` to `2.0-rc.7`
+* Added `org.springframework:spring-beans:7.0.8`
 
 ### Test Dependency Updates
 
-* Updated `org.junit.jupiter:junit-jupiter:6.1.0` to `6.1.1`
+* Updated `org.junit.jupiter:junit-jupiter:6.1.0` to `6.1.2`
 
 ### Plugin Dependency Updates
 

--- a/doc/changes/changes_2.0.1.md
+++ b/doc/changes/changes_2.0.1.md
@@ -15,6 +15,7 @@ We also updated the GitHub API to 2.0-RC7 and adapted some code to match that. W
 ### Compile Dependency Updates
 
 * Updated `com.atlassian.jira:jira-rest-java-client-core:7.0.1` to `7.0.2`
+* Removed `com.exasol:error-reporting-java:1.0.2`
 * Updated `com.fasterxml.jackson.core:jackson-databind:2.22.0` to `2.22.1`
 * Removed `com.infradna.tool:bridge-method-annotation:1.31`
 * Removed `jakarta.json:jakarta.json-api:2.1.3`

--- a/doc/changes/changes_2.0.1.md
+++ b/doc/changes/changes_2.0.1.md
@@ -15,7 +15,6 @@ We also updated the GitHub API to 2.0-RC7 and adapted some code to match that. W
 ### Compile Dependency Updates
 
 * Updated `com.atlassian.jira:jira-rest-java-client-core:7.0.1` to `7.0.2`
-* Removed `com.exasol:error-reporting-java:1.0.2`
 * Updated `com.fasterxml.jackson.core:jackson-databind:2.22.0` to `2.22.1`
 * Removed `com.infradna.tool:bridge-method-annotation:1.31`
 * Removed `jakarta.json:jakarta.json-api:2.1.3`

--- a/doc/changes/changes_2.0.1.md
+++ b/doc/changes/changes_2.0.1.md
@@ -10,6 +10,139 @@ The Jira client does not have an update yet, so we had to pin two transitive dep
 
 We also updated the GitHub API to 2.0-RC7 and adapted some code to match that. While we were at it, we fixed some Sonar findings.
 
+This release fixes the following 10 vulnerabilities:
+
+### CVE-2026-8484 (CWE-122) in dependency `org.fusesource.jansi:jansi:jar:2.4.3:compile`
+A heap buffer overflow vulnerability exists in the Jansi JNI "ioctl()" wrapper due to a lack of size verification for the argument array before the system call. This can lead to heap corruption and application crashes (DoS).
+All versions are believed to be vulnerable.Â This project is unmaintained at the time of CVE assignment.
+#### References
+* https://guide.sonatype.com/vulnerability/CVE-2026-8484?component-type=maven&component-name=org.fusesource.jansi%2Fjansi&utm_source=ossindex-client&utm_medium=integration&utm_content=1.8.1
+* http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2026-8484
+* https://cert.pl/en/posts/2026/06/CVE-2026-8484
+
+### CVE-2025-48924 (CWE-674) in dependency `org.apache.commons:commons-lang3:jar:3.17.0:compile`
+Uncontrolled Recursion vulnerability in Apache Commons Lang.
+
+This issue affects Apache Commons Lang: Starting withÂ commons-lang:commons-langÂ 2.0 to 2.6, and, from org.apache.commons:commons-lang3 3.0 beforeÂ 3.18.0.
+
+The methods ClassUtils.getClass(...) can throwÂ StackOverflowError on very long inputs. Because an Error is usually not handled by applications and libraries, a
+StackOverflowError couldÂ cause an application to stop.
+
+Users are recommended to upgrade to version 3.18.0, which fixes the issue.
+
+Sonatype's research suggests that this CVE's details differ from those defined at NVD. See https://guide.sonatype.com/vulnerability/CVE-2025-48924 for details
+#### References
+* https://guide.sonatype.com/vulnerability/CVE-2025-48924?component-type=maven&component-name=org.apache.commons%2Fcommons-lang3&utm_source=ossindex-client&utm_medium=integration&utm_content=1.8.1
+* http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2025-48924
+* https://github.com/advisories/GHSA-j288-q9x7-2f5v
+
+### CVE-2025-41242 (CWE-22) in dependency `org.springframework:spring-core:jar:6.2.8:compile`
+Spring Framework MVC applications can be vulnerable to a âPath Traversal Vulnerabilityâ when deployed on a non-compliant Servlet container.
+
+An application can be vulnerable when all the following are true:
+
+*  the application is deployed as a WAR or with an embedded Servlet container
+*  the Servlet container  does not reject suspicious sequences https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1.html#uri-path-canonicalization
+*  the application  serves static resources https://docs.spring.io/spring-framework/reference/web/webmvc/mvc-config/static-resources.html#page-title Â with Spring resource handling
+
+We have verified that applications deployed on Apache Tomcat or Eclipse Jetty are not vulnerable, as long as default security features are not disabled in the configuration. Because we cannot check exploits against all Servlet containers and configuration variants, we strongly recommend upgrading your application.
+
+Sonatype's research suggests that this CVE's details differ from those defined at NVD. See https://guide.sonatype.com/vulnerability/CVE-2025-41242 for details
+#### References
+* https://guide.sonatype.com/vulnerability/CVE-2025-41242?component-type=maven&component-name=org.springframework%2Fspring-core&utm_source=ossindex-client&utm_medium=integration&utm_content=1.8.1
+* http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2025-41242
+* https://spring.io/security/cve-2025-41242
+
+### CVE-2025-41249 (CWE-285) in dependency `org.springframework:spring-core:jar:6.2.8:compile`
+The Spring Framework annotation detection mechanism may not correctly resolve annotations on methods within type hierarchies with a parameterized super type with unbounded generics. This can be an issue if such annotations are used for authorization decisions.
+
+Your application may be affected by this if you are using Spring Security's @EnableMethodSecurityÂ feature.
+
+You are not affected by this if you are not using @EnableMethodSecurityÂ or if you do not use security annotations on methods in generic superclasses or generic interfaces.
+
+This CVE is published in conjunction with  CVE-2025-41248 https://spring.io/security/cve-2025-41248 .
+
+Sonatype's research suggests that this CVE's details differ from those defined at NVD. See https://guide.sonatype.com/vulnerability/CVE-2025-41249 for details
+#### References
+* https://guide.sonatype.com/vulnerability/CVE-2025-41249?component-type=maven&component-name=org.springframework%2Fspring-core&utm_source=ossindex-client&utm_medium=integration&utm_content=1.8.1
+* http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2025-41249
+* https://spring.io/security/cve-2025-41249
+
+### CVE-2026-22745 (CWE-400) in dependency `org.springframework:spring-core:jar:6.2.8:compile`
+Spring MVC and WebFlux applications are vulnerable to Denial of Service attacks when resolving static resources.
+
+More precisely, an application can be vulnerable when all the following are true:
+
+*  the application is using Spring MVC or Spring WebFlux
+*  the application is serving static resources from the file system
+*  the application is running on a Windows platform
+
+When all the conditions above are met, the attacker can send malicious requests that are slow to resolve and that can keep HTTP connections in use. This can cause a Denial of Service on the application.
+#### References
+* https://guide.sonatype.com/vulnerability/CVE-2026-22745?component-type=maven&component-name=org.springframework%2Fspring-core&utm_source=ossindex-client&utm_medium=integration&utm_content=1.8.1
+* http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2026-22745
+* https://spring.io/security/cve-2026-22745
+
+### CVE-2026-41842 (CWE-400) in dependency `org.springframework:spring-core:jar:6.2.8:compile`
+Spring MVC and WebFlux applications are vulnerable to Denial of Service (DoS) attacks when resolving static resources.
+
+Affected versions:
+Spring Framework 7.0.0 through 7.0.7; 6.2.0 through 6.2.18; 6.1.0 through 6.1.27; 5.3.0 through 5.3.48.
+#### References
+* https://guide.sonatype.com/vulnerability/CVE-2026-41842?component-type=maven&component-name=org.springframework%2Fspring-core&utm_source=ossindex-client&utm_medium=integration&utm_content=1.8.1
+* http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2026-41842
+* https://spring.io/security/cve-2026-41842
+
+### CVE-2026-41848 (CWE-1333) in dependency `org.springframework:spring-core:jar:6.2.8:compile`
+Applications may be vulnerable to a Regular Expression Denial of Service (ReDoS) attack if an attacker is able to provide a pattern which is then directly or indirectly supplied to one of the following methods in AntPathMatcher: match(String pattern, String path), matchStart(String pattern, String path), extractUriTemplateVariables(String pattern, String path).
+
+Affected versions:
+Spring Framework 7.0.0 through 7.0.7; 6.2.0 through 6.2.18; 6.1.0 through 6.1.27; 5.3.0 through 5.3.48.
+
+Sonatype's research suggests that this CVE's details differ from those defined at NVD. See https://guide.sonatype.com/vulnerability/CVE-2026-41848 for details
+#### References
+* https://guide.sonatype.com/vulnerability/CVE-2026-41848?component-type=maven&component-name=org.springframework%2Fspring-core&utm_source=ossindex-client&utm_medium=integration&utm_content=1.8.1
+* http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2026-41848
+* https://spring.io/security/cve-2026-41848
+
+### CVE-2026-41853 (CWE-444) in dependency `org.springframework:spring-core:jar:6.2.8:compile`
+Spring MVC and WebFlux applications are vulnerable to Multipart request smuggling attacks.
+
+Affected versions:
+Spring Framework 7.0.0 through 7.0.7; 6.2.0 through 6.2.18; 6.1.0 through 6.1.27; 5.3.0 through 5.3.48.
+#### References
+* https://guide.sonatype.com/vulnerability/CVE-2026-41853?component-type=maven&component-name=org.springframework%2Fspring-core&utm_source=ossindex-client&utm_medium=integration&utm_content=1.8.1
+* http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2026-41853
+* https://spring.io/security/cve-2026-41853
+
+### CVE-2026-54515 (CWE-915) in dependency `com.fasterxml.jackson.core:jackson-databind:jar:2.22.0:compile`
+jackson-databind contains the general-purpose data-binding functionality and tree-model for Jackson Data Processor. From 2.8.0 until 2.18.9, 2.21.5, and 3.1.4, in BeanDeserializerBase.createContextual(), per-property @JsonIgnoreProperties exclusions are applied by _handleByNameInclusion(), producing a contextual deserializer whose BeanPropertyMap has the ignored properties removed. The subsequent per-property case-insensitivity block (triggered by @JsonFormat(ACCEPT_CASE_INSENSITIVE_PROPERTIES)) rebuilds from this._beanProperties (the original, unfiltered map) instead of contextual._beanProperties, then overwrites the filtered map â restoring every property _handleByNameInclusion had just removed. The ignored property becomes writable again. This vulnerability is fixed in 2.18.9, 2.21.5, and 3.1.4.
+#### References
+* https://guide.sonatype.com/vulnerability/CVE-2026-54515?component-type=maven&component-name=com.fasterxml.jackson.core%2Fjackson-databind&utm_source=ossindex-client&utm_medium=integration&utm_content=1.8.1
+* http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2026-54515
+* https://github.com/FasterXML/jackson-databind/security/advisories/GHSA-5jmj-h7xm-6q6v
+
+### CVE-2026-59889 (CWE-863) in dependency `com.fasterxml.jackson.core:jackson-databind:jar:2.22.0:compile`
+Jackson Databind -  Authorization bypass on JsonView Setter/Field
+#### References
+* https://guide.sonatype.com/vulnerability/CVE-2026-59889?component-type=maven&component-name=com.fasterxml.jackson.core%2Fjackson-databind&utm_source=ossindex-client&utm_medium=integration&utm_content=1.8.1
+* http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2026-59889
+* https://github.com/FasterXML/jackson-databind/issues/6060
+* https://github.com/FasterXML/jackson-databind/pull/6056
+
+## Security
+
+* #314: Fixed vulnerability CVE-2026-8484 in dependency `org.fusesource.jansi:jansi:jar:2.4.3:compile`
+* #315: Fixed vulnerability CVE-2025-48924 in dependency `org.apache.commons:commons-lang3:jar:3.17.0:compile`
+* #316: Fixed vulnerability CVE-2025-41242 in dependency `org.springframework:spring-core:jar:6.2.8:compile`
+* #317: Fixed vulnerability CVE-2025-41249 in dependency `org.springframework:spring-core:jar:6.2.8:compile`
+* #318: Fixed vulnerability CVE-2026-22745 in dependency `org.springframework:spring-core:jar:6.2.8:compile`
+* #319: Fixed vulnerability CVE-2026-41842 in dependency `org.springframework:spring-core:jar:6.2.8:compile`
+* #320: Fixed vulnerability CVE-2026-41848 in dependency `org.springframework:spring-core:jar:6.2.8:compile`
+* #321: Fixed vulnerability CVE-2026-41853 in dependency `org.springframework:spring-core:jar:6.2.8:compile`
+* #322: Fixed vulnerability CVE-2026-54515 in dependency `com.fasterxml.jackson.core:jackson-databind:jar:2.22.0:compile`
+* #323: Fixed vulnerability CVE-2026-59889 in dependency `com.fasterxml.jackson.core:jackson-databind:jar:2.22.0:compile`
+
 ## Dependency Updates
 
 ### Compile Dependency Updates

--- a/doc/changes/changes_2.0.1.md
+++ b/doc/changes/changes_2.0.1.md
@@ -1,0 +1,36 @@
+# Exasol Release Droid 2.0.1, released 2026-??-??
+
+Code name: Dependency Update on top of 2.0.0
+
+## Summary
+
+This release fixes CWE-915 by updating the transitive dependency `com.fasterxml.jackson.core:jackson-databind` to 2.22.0 
+
+## Security
+
+* ISSUE_NUMBER: description
+
+## Dependency Updates
+
+### Compile Dependency Updates
+
+* Updated `com.atlassian.jira:jira-rest-java-client-core:7.0.1` to `7.0.2`
+* Updated `org.commonmark:commonmark:0.28.0` to `0.29.0`
+
+### Test Dependency Updates
+
+* Updated `org.junit.jupiter:junit-jupiter:6.1.0` to `6.1.1`
+
+### Plugin Dependency Updates
+
+* Updated `com.exasol:artifact-reference-checker-maven-plugin:0.4.4` to `1.0.0`
+* Updated `com.exasol:error-code-crawler-maven-plugin:2.0.7` to `2.1.0`
+* Updated `com.exasol:project-keeper-maven-plugin:5.6.2` to `5.7.3`
+* Removed `com.exasol:quality-summarizer-maven-plugin:0.2.1`
+* Updated `org.apache.maven.plugins:maven-dependency-plugin:3.10.0` to `3.11.0`
+* Updated `org.apache.maven.plugins:maven-enforcer-plugin:3.6.2` to `3.6.3`
+* Updated `org.apache.maven.plugins:maven-failsafe-plugin:3.5.5` to `3.5.6`
+* Updated `org.apache.maven.plugins:maven-surefire-plugin:3.5.5` to `3.5.6`
+* Updated `org.jacoco:jacoco-maven-plugin:0.8.14` to `0.8.15`
+* Updated `org.sonarsource.scanner.maven:sonar-maven-plugin:5.5.0.6356` to `5.7.0.6970`
+* Added `org.spdx:spdx-maven-plugin:1.0.4`

--- a/doc/changes/changes_2.0.1.md
+++ b/doc/changes/changes_2.0.1.md
@@ -15,7 +15,11 @@ This release fixes CWE-915 by updating the transitive dependency `com.fasterxml.
 ### Compile Dependency Updates
 
 * Updated `com.atlassian.jira:jira-rest-java-client-core:7.0.1` to `7.0.2`
+* Updated `com.fasterxml.jackson.core:jackson-databind:2.22.0` to `2.22.1`
+* Removed `com.infradna.tool:bridge-method-annotation:1.31`
 * Updated `org.commonmark:commonmark:0.28.0` to `0.29.0`
+* Removed `org.eclipse.parsson:parsson:1.1.9`
+* Updated `org.kohsuke:github-api:1.330` to `2.0-rc.7`
 
 ### Test Dependency Updates
 
@@ -23,9 +27,9 @@ This release fixes CWE-915 by updating the transitive dependency `com.fasterxml.
 
 ### Plugin Dependency Updates
 
-* Updated `com.exasol:artifact-reference-checker-maven-plugin:0.4.4` to `1.0.0`
+* Updated `com.exasol:artifact-reference-checker-maven-plugin:0.4.4` to `1.0.1`
 * Updated `com.exasol:error-code-crawler-maven-plugin:2.0.7` to `2.1.0`
-* Updated `com.exasol:project-keeper-maven-plugin:5.6.2` to `5.7.3`
+* Updated `com.exasol:project-keeper-maven-plugin:5.6.2` to `5.7.4`
 * Removed `com.exasol:quality-summarizer-maven-plugin:0.2.1`
 * Updated `org.apache.maven.plugins:maven-dependency-plugin:3.10.0` to `3.11.0`
 * Updated `org.apache.maven.plugins:maven-enforcer-plugin:3.6.2` to `3.6.3`

--- a/doc/changes/changes_2.0.1.md
+++ b/doc/changes/changes_2.0.1.md
@@ -20,6 +20,8 @@ We also updated the GitHub API to 2.0-RC7 and adapted some code to match that. W
 * Removed `jakarta.json:jakarta.json-api:2.1.3`
 * Added `org.apache.commons:commons-lang3:3.20.0`
 * Updated `org.commonmark:commonmark:0.28.0` to `0.29.0`
+* Removed `org.fusesource.jansi:jansi:2.4.3`
+* Added `org.jline:jansi:4.3.1`
 * Updated `org.kohsuke:github-api:1.330` to `2.0-rc.7`
 * Added `org.springframework:spring-beans:7.0.8`
 

--- a/doc/changes/changes_2.0.1.md
+++ b/doc/changes/changes_2.0.1.md
@@ -1,14 +1,14 @@
-# Exasol Release Droid 2.0.1, released 2026-??-??
+# Exasol Release Droid 2.0.1, released 2026-07-27
 
 Code name: Dependency Update on top of 2.0.0
 
 ## Summary
 
-This release fixes CWE-915 by updating the transitive dependency `com.fasterxml.jackson.core:jackson-databind` to 2.22.0 
+This release fixes CWE-915 by updating the transitive dependency `com.fasterxml.jackson.core:jackson-databind` to 2.22.1.
 
-## Security
+The Jira client does not have an update yet, so we had to pin two transitive dependencies.
 
-* ISSUE_NUMBER: description
+We also updated the GitHub API to 2.0-RC7 and adapted some code to match that. While we were at it, we fixed some Sonar findings.
 
 ## Dependency Updates
 

--- a/doc/user_guide/user_guide.md
+++ b/doc/user_guide/user_guide.md
@@ -173,13 +173,13 @@ Section [Release Guide](#release-guide) describes optional additional entries.
 
 1. Run Release Droid from a terminal:
 
-   `java -jar release-droid-2.0.0.jar -name <project name> -goal <goal> -platforms <comma-separated list of platforms>`
+   `java -jar release-droid-2.0.1.jar -name <project name> -goal <goal> -platforms <comma-separated list of platforms>`
 
    For example:
 
-   `java -jar release-droid-2.0.0.jar -name virtual-schema-common-java -goal validate -platforms github`
+   `java -jar release-droid-2.0.1.jar -name virtual-schema-common-java -goal validate -platforms github`
 
-   (Optional) Windows: You can simplify this by creating a `release-droid.bat` file containing the following contents `java -jar C:\tools\release-droid-2.0.0.jar %*`.
+   (Optional) Windows: You can simplify this by creating a `release-droid.bat` file containing the following contents `java -jar C:\tools\release-droid-2.0.1.jar %*`.
    Make sure you use the full path for the .jar file and don't forget to include the location of your new batch file in your PATH so you can always access it from your CLI.
    You can just use the name of the .bat file you created from then on e.g.:
    `release-droid -name virtual-schema-common-java -goal validate ...`

--- a/pk_generated_parent.pom
+++ b/pk_generated_parent.pom
@@ -301,7 +301,7 @@
             <plugin>
                 <groupId>com.exasol</groupId>
                 <artifactId>artifact-reference-checker-maven-plugin</artifactId>
-                <version>1.0.0</version>
+                <version>1.0.1</version>
                 <executions>
                     <execution>
                         <id>verify</id>

--- a/pk_generated_parent.pom
+++ b/pk_generated_parent.pom
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.exasol</groupId>
     <artifactId>release-droid-generated-parent</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <packaging>pom</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -57,7 +57,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.21.0</version>
+                    <version>3.22.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -75,7 +75,7 @@
             <plugin>
                 <groupId>org.sonarsource.scanner.maven</groupId>
                 <artifactId>sonar-maven-plugin</artifactId>
-                <version>5.5.0.6356</version>
+                <version>5.7.0.6970</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -101,8 +101,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.15.0</version>
                 <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
+                    <release>${java.version}</release>
                     <showWarnings>true</showWarnings>
                     <compilerArgs>
                         <arg>-Xlint:all</arg>
@@ -113,7 +112,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.6.2</version>
+                <version>3.6.3</version>
                 <executions>
                     <execution>
                         <id>enforce-maven</id>
@@ -180,7 +179,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.5</version>
+                <version>3.5.6</version>
                 <configuration>
                     <argLine>-javaagent:${org.mockito:mockito-core:jar} ${argLine}</argLine>
                     <environmentVariables>
@@ -302,7 +301,7 @@
             <plugin>
                 <groupId>com.exasol</groupId>
                 <artifactId>artifact-reference-checker-maven-plugin</artifactId>
-                <version>0.4.4</version>
+                <version>1.0.0</version>
                 <executions>
                     <execution>
                         <id>verify</id>
@@ -313,9 +312,38 @@
                 </executions>
             </plugin>
             <plugin>
+                <!-- [impl->dsn~release-workflow.publish-release-sboms~0] -->
+                <groupId>org.spdx</groupId>
+                <artifactId>spdx-maven-plugin</artifactId>
+                <version>1.0.4</version>
+                <executions>
+                    <execution>
+                        <id>build-spdx</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>createSPDX</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <sbomType>build</sbomType>
+                    <!-- Exclude source code files -->
+                    <useArtifactID>true</useArtifactID>
+                    <includeCompileScope>true</includeCompileScope>
+                    <includeRuntimeScope>true</includeRuntimeScope>
+                    <includeProvidedScope>true</includeProvidedScope>
+                    <includeSystemScope>false</includeSystemScope>
+                    <includeTestScope>false</includeTestScope>
+                    <copyrightText>Copyright (c) Exasol</copyrightText>
+                    <createExternalRefs>false</createExternalRefs>
+                    <outputFormat>JSON-LD</outputFormat>
+                    <spdxFile>${project.build.directory}/site/${project.groupId}.${project.artifactId}-${project.version}.spdx3.json</spdxFile>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.10.0</version>
+                <version>3.11.0</version>
                 <executions>
                     <execution>
                         <goals>
@@ -328,7 +356,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.5.5</version>
+                <version>3.5.6</version>
                 <configuration>
                     <argLine>-javaagent:${org.mockito:mockito-core:jar} ${argLine}</argLine>
                     <environmentVariables>
@@ -353,7 +381,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.14</version>
+                <version>0.8.15</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>
@@ -393,21 +421,8 @@
             </plugin>
             <plugin>
                 <groupId>com.exasol</groupId>
-                <artifactId>quality-summarizer-maven-plugin</artifactId>
-                <version>0.2.1</version>
-                <executions>
-                    <execution>
-                        <id>summarize-metrics</id>
-                        <goals>
-                            <goal>summarize</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>com.exasol</groupId>
                 <artifactId>error-code-crawler-maven-plugin</artifactId>
-                <version>2.0.7</version>
+                <version>2.1.0</version>
                 <executions>
                     <execution>
                         <id>verify</id>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>release-droid</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <name>Exasol Release Droid</name>
     <description>Release Droid automates release process steps on widely used platforms like GitHub and Maven</description>
     <url>https://github.com/exasol/release-droid/</url>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.atlassian.jira</groupId>
             <artifactId>jira-rest-java-client-core</artifactId>
-            <version>7.0.1</version>
+            <version>7.0.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>
@@ -39,9 +39,11 @@
         <dependency>
             <groupId>org.kohsuke</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.330</version>
+            <version>2.0-rc.7</version>
         </dependency>
-        <!-- transitive dependencies of github-api expected to be provided since version 1.326 -->
+        <!--
+        Transitive dependencies of github-api expected to be provided since version 1.326.
+        Keep these disabled while evaluating whether a github-api update supplies them.
         <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
@@ -54,10 +56,12 @@
             <version>1.31</version>
             <optional>true</optional>
         </dependency>
+        -->
         <dependency>
+            <!-- Transitive dependency of github-api, pinned to fix CWE-915. -->
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.22.0</version>
+            <version>2.22.1</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
@@ -86,12 +90,15 @@
             <artifactId>yasson</artifactId>
             <version>3.0.4</version>
         </dependency>
+        <!--
+        Transitive dependency of Yasson, pinned to fix CVE-2023-4043.
+        Keep this disabled while evaluating whether a Yasson update supplies it.
         <dependency>
-            <!-- override transitive dependency of yasson to fix vulnerability CVE-2023-4043 -->
             <groupId>org.eclipse.parsson</groupId>
             <artifactId>parsson</artifactId>
             <version>1.1.9</version>
         </dependency>
+        -->
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-model</artifactId>
@@ -105,7 +112,7 @@
         <dependency>
             <groupId>org.commonmark</groupId>
             <artifactId>commonmark</artifactId>
-            <version>0.28.0</version>
+            <version>0.29.0</version>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>
@@ -121,7 +128,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>6.1.0</version>
+            <version>6.1.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -183,7 +190,7 @@
             <plugin>
                 <groupId>com.exasol</groupId>
                 <artifactId>project-keeper-maven-plugin</artifactId>
-                <version>5.6.2</version>
+                <version>5.7.3</version>
                 <executions>
                     <execution>
                         <goals>
@@ -243,7 +250,7 @@
     <parent>
         <artifactId>release-droid-generated-parent</artifactId>
         <groupId>com.exasol</groupId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
         <relativePath>pk_generated_parent.pom</relativePath>
     </parent>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,18 @@
             </exclusions>
         </dependency>
         <dependency>
+            <!-- Transitive dependency of jira-rest-java-client-core, pinned to fix CVE-2025-41249, CVE-2025-41242 -->
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-beans</artifactId>
+            <version>7.0.8</version>
+        </dependency>
+        <dependency>
+            <!-- Transitive dependency of jira-rest-java-client-core, pinned to fix CVE-2025-48924 -->
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.20.0</version>
+        </dependency>
+        <dependency>
             <groupId>io.atlassian.fugue</groupId>
             <artifactId>fugue</artifactId>
             <version>6.1.4</version>
@@ -41,22 +53,6 @@
             <artifactId>github-api</artifactId>
             <version>2.0-rc.7</version>
         </dependency>
-        <!--
-        Transitive dependencies of github-api expected to be provided since version 1.326.
-        Keep these disabled while evaluating whether a github-api update supplies them.
-        <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
-            <version>4.10.2</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.infradna.tool</groupId>
-            <artifactId>bridge-method-annotation</artifactId>
-            <version>1.31</version>
-            <optional>true</optional>
-        </dependency>
-        -->
         <dependency>
             <!-- Transitive dependency of github-api, pinned to fix CWE-915. -->
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -80,25 +76,20 @@
             <!-- Do not use version like 20040117.000000 -->
             <version>1.11.0</version>
         </dependency>
+        <!--
+        Transitive dependency of Yasson. Keep this disabled while evaluating
+        whether a Yasson update continues to supply the required JSON API.
         <dependency>
             <groupId>jakarta.json</groupId>
             <artifactId>jakarta.json-api</artifactId>
             <version>2.1.3</version>
         </dependency>
+        -->
         <dependency>
             <groupId>org.eclipse</groupId>
             <artifactId>yasson</artifactId>
             <version>3.0.4</version>
         </dependency>
-        <!--
-        Transitive dependency of Yasson, pinned to fix CVE-2023-4043.
-        Keep this disabled while evaluating whether a Yasson update supplies it.
-        <dependency>
-            <groupId>org.eclipse.parsson</groupId>
-            <artifactId>parsson</artifactId>
-            <version>1.1.9</version>
-        </dependency>
-        -->
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-model</artifactId>
@@ -128,7 +119,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>6.1.1</version>
+            <version>6.1.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -190,7 +181,7 @@
             <plugin>
                 <groupId>com.exasol</groupId>
                 <artifactId>project-keeper-maven-plugin</artifactId>
-                <version>5.7.3</version>
+                <version>5.7.4</version>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,13 @@
                 <artifactId>maven-site-plugin</artifactId>
                 <version>3.12.1</version>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -76,19 +76,16 @@
             <!-- Do not use version like 20040117.000000 -->
             <version>1.11.0</version>
         </dependency>
-        <!--
-        Transitive dependency of Yasson. Keep this disabled while evaluating
-        whether a Yasson update continues to supply the required JSON API.
-        <dependency>
-            <groupId>jakarta.json</groupId>
-            <artifactId>jakarta.json-api</artifactId>
-            <version>2.1.3</version>
-        </dependency>
-        -->
         <dependency>
             <groupId>org.eclipse</groupId>
             <artifactId>yasson</artifactId>
             <version>3.0.4</version>
+        </dependency>
+        <dependency>
+            <!-- Transitive dependency of yasson, pinned to fix CVE-2026-9563 -->
+            <groupId>org.eclipse.parsson</groupId>
+            <artifactId>parsson</artifactId>
+            <version>1.1.9</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -93,11 +93,6 @@
             <version>3.9.16</version>
         </dependency>
         <dependency>
-            <groupId>com.exasol</groupId>
-            <artifactId>error-reporting-java</artifactId>
-            <version>1.0.2</version>
-        </dependency>
-        <dependency>
             <groupId>org.commonmark</groupId>
             <artifactId>commonmark</artifactId>
             <version>0.29.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,11 @@
             <version>3.9.16</version>
         </dependency>
         <dependency>
+            <groupId>com.exasol</groupId>
+            <artifactId>error-reporting-java</artifactId>
+            <version>1.0.2</version>
+        </dependency>
+        <dependency>
             <groupId>org.commonmark</groupId>
             <artifactId>commonmark</artifactId>
             <version>0.29.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -108,9 +108,9 @@
             <version>2.6</version>
         </dependency>
         <dependency>
-            <groupId>org.fusesource.jansi</groupId>
+            <groupId>org.jline</groupId>
             <artifactId>jansi</artifactId>
-            <version>2.4.3</version>
+            <version>4.3.1</version>
         </dependency>
         <!--Unit test dependencies-->
         <dependency>

--- a/src/main/java/com/exasol/releasedroid/adapter/github/GitHubAPIAdapter.java
+++ b/src/main/java/com/exasol/releasedroid/adapter/github/GitHubAPIAdapter.java
@@ -127,10 +127,10 @@ public class GitHubAPIAdapter implements GitHubGateway {
     }
 
     @Override
-    @SuppressWarnings("deprecation") // getIssues is deprecated.
     public Set<Integer> getClosedTickets(final String repositoryName) throws GitHubException {
         try {
-            final List<GHIssue> closedIssues = this.getRepository(repositoryName).getIssues(GHIssueState.CLOSED);
+            final List<GHIssue> closedIssues = this.getRepository(repositoryName).queryIssues().state(GHIssueState.CLOSED)
+                    .list().toList();
             return closedIssues.stream().filter(ghIssue -> !ghIssue.isPullRequest()).map(GHIssue::getNumber)
                     .collect(Collectors.toSet());
         } catch (final IOException exception) {

--- a/src/main/java/com/exasol/releasedroid/adapter/github/GitHubAPIAdapter.java
+++ b/src/main/java/com/exasol/releasedroid/adapter/github/GitHubAPIAdapter.java
@@ -127,6 +127,7 @@ public class GitHubAPIAdapter implements GitHubGateway {
     }
 
     @Override
+    @SuppressWarnings("deprecation") // getIssues is deprecated.
     public Set<Integer> getClosedTickets(final String repositoryName) throws GitHubException {
         try {
             final List<GHIssue> closedIssues = this.getRepository(repositoryName).getIssues(GHIssueState.CLOSED);
@@ -213,7 +214,7 @@ public class GitHubAPIAdapter implements GitHubGateway {
      */
     // [impl->dsn~progress-display~1]
     private String getWorkflowConclusion(final GHWorkflow workflow, final WorkflowOptions options)
-            throws GitHubException, IOException {
+            throws GitHubException {
         boolean reportUrl = true;
         final Duration timeout = Duration.ofMinutes(150);
         final Timer timer = new Timer() //

--- a/src/main/java/com/exasol/releasedroid/formatting/Colorizer.java
+++ b/src/main/java/com/exasol/releasedroid/formatting/Colorizer.java
@@ -1,10 +1,10 @@
 package com.exasol.releasedroid.formatting;
 
-import static org.fusesource.jansi.Ansi.ansi;
+import static org.jline.jansi.Ansi.ansi;
 
 import java.net.URL;
 
-import org.fusesource.jansi.Ansi.Attribute;
+import org.jline.jansi.Ansi.Attribute;
 
 public class Colorizer {
 

--- a/src/main/java/com/exasol/releasedroid/main/Runner.java
+++ b/src/main/java/com/exasol/releasedroid/main/Runner.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
-import org.fusesource.jansi.AnsiConsole;
+import org.jline.jansi.AnsiConsole;
 
 import com.exasol.errorreporting.ExaError;
 import com.exasol.releasedroid.adapter.ReleaseManagerImpl;

--- a/src/main/java/com/exasol/releasedroid/progress/Estimation.java
+++ b/src/main/java/com/exasol/releasedroid/progress/Estimation.java
@@ -2,7 +2,6 @@ package com.exasol.releasedroid.progress;
 
 import java.time.*;
 import java.time.format.DateTimeFormatter;
-import java.util.Date;
 import java.util.Objects;
 
 // [impl->dsn~estimate-duration~1]
@@ -30,9 +29,8 @@ public class Estimation {
      * @param end   end of time period to compute estimation from
      * @return duration representing the estimation
      */
-    public static Estimation from(final Date start, final Date end) {
-        final Instant startInstant = start.toInstant();
-        return new Estimation(startInstant, Duration.between(startInstant, end.toInstant()));
+    public static Estimation from(final Instant start, final Instant end) {
+        return new Estimation(start, Duration.between(start, end));
     }
 
     private final Instant timestamp;

--- a/src/test/java/com/exasol/releasedroid/adapter/github/GitHubAPIAdapterTest.java
+++ b/src/test/java/com/exasol/releasedroid/adapter/github/GitHubAPIAdapterTest.java
@@ -13,7 +13,9 @@ import static org.mockito.Mockito.*;
 import java.io.IOException;
 import java.net.*;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -86,6 +88,22 @@ class GitHubAPIAdapterTest {
         final String language = "Java";
         when(this.repositoryMock.getLanguage()).thenReturn(language);
         assertThat(this.apiAdapter.getRepositoryPrimaryLanguage(REPOSITORY_NAME), equalTo(language));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void getClosedTickets() throws IOException, GitHubException {
+        final GHIssue issue = mock(GHIssue.class);
+        when(issue.getNumber()).thenReturn(123);
+        final GHIssue pullRequest = mock(GHIssue.class);
+        when(pullRequest.isPullRequest()).thenReturn(true);
+        final GHIssueQueryBuilder.ForRepository query = mock(GHIssueQueryBuilder.ForRepository.class);
+        final PagedIterable<GHIssue> issues = mock(PagedIterable.class);
+        when(this.repositoryMock.queryIssues()).thenReturn(query);
+        when(query.state(GHIssueState.CLOSED)).thenReturn(query);
+        when(query.list()).thenReturn(issues);
+        when(issues.toList()).thenReturn(List.of(issue, pullRequest));
+        assertThat(this.apiAdapter.getClosedTickets(REPOSITORY_NAME), equalTo(Set.of(123)));
     }
 
     @ParameterizedTest

--- a/src/test/java/com/exasol/releasedroid/adapter/github/GitHubAPIAdapterTest.java
+++ b/src/test/java/com/exasol/releasedroid/adapter/github/GitHubAPIAdapterTest.java
@@ -1,12 +1,12 @@
 package com.exasol.releasedroid.adapter.github;
 
-import static com.exasol.releasedroid.usecases.ReleaseDroidConstants.FILE_SEPARATOR;
-import static com.exasol.releasedroid.usecases.ReleaseDroidConstants.RELEASE_DROID_DIRECTORY;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -17,15 +17,15 @@ import java.util.Map;
 
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.kohsuke.github.*;
 import org.kohsuke.github.GHWorkflowRun.Conclusion;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.exasol.releasedroid.progress.Estimation;
 import com.exasol.releasedroid.progress.Progress;
-import com.exasol.releasedroid.usecases.PropertyReaderImpl;
 
 @ExtendWith(MockitoExtension.class)
 class GitHubAPIAdapterTest {
@@ -59,24 +59,24 @@ class GitHubAPIAdapterTest {
     }
 
     private GHWorkflowRun mockWorkflowRun() throws IOException, URISyntaxException {
-        final GHWorkflowRun run = Mockito.mock(GHWorkflowRun.class);
+        final GHWorkflowRun run = mock(GHWorkflowRun.class);
         when(run.getHtmlUrl()).thenReturn(new URI("http://of-workflow-run").toURL());
         when(run.getConclusion()).thenReturn(Conclusion.SUCCESS);
         return run;
     }
 
     @SuppressWarnings("unchecked")
-    private GHWorkflow mockWorkflow(final GHWorkflowRun run) throws IOException {
-        final PagedIterator<GHWorkflowRun> ptor = Mockito.mock(PagedIterator.class);
+    private GHWorkflow mockWorkflow(final GHWorkflowRun run) {
+        final PagedIterator<GHWorkflowRun> ptor = mock(PagedIterator.class);
         when(ptor.hasNext()).thenReturn(run != null);
         if (run != null) {
             when(ptor.next()).thenReturn(run);
         }
 
-        final PagedIterable<GHWorkflowRun> pable = Mockito.mock(PagedIterable.class);
+        final PagedIterable<GHWorkflowRun> pable = mock(PagedIterable.class);
         when(pable.iterator()).thenReturn(ptor);
 
-        final GHWorkflow workflow = Mockito.mock(GHWorkflow.class);
+        final GHWorkflow workflow = mock(GHWorkflow.class);
         when(workflow.listRuns()).thenReturn(pable);
         return workflow;
     }
@@ -88,11 +88,22 @@ class GitHubAPIAdapterTest {
         assertThat(this.apiAdapter.getRepositoryPrimaryLanguage(REPOSITORY_NAME), equalTo(language));
     }
 
+    @ParameterizedTest
+    @CsvSource({ "Not Found, E-RD-GH-1", "Bad credentials, E-RD-GH-13", "Unexpected response, E-RD-GH-14" })
+    void wrapGitHubException(final String originalMessage, final String errorCode) throws IOException {
+        reset(this.gitHubMock);
+        final IOException cause = new IOException(originalMessage);
+        doThrow(cause).when(this.gitHubMock).getRepository(REPOSITORY_NAME);
+        final GitHubException exception = assertThrows(GitHubException.class,
+                () -> this.apiAdapter.getRepositoryPrimaryLanguage(REPOSITORY_NAME));
+        assertAll(() -> assertThat(exception.getMessage(), containsString(errorCode)),
+                () -> assertThat(exception.getCause(), is(cause)));
+    }
+
     @Test
     void testDownloadArtifactAsString() throws IOException, GitHubException {
         final long artifactId = 123;
-        final GHArtifact artifactMock = Mockito.mock(GHArtifact.class);
-        final GHRepository repositoryMock = Mockito.mock(GHRepository.class);
+        final GHArtifact artifactMock = mock(GHArtifact.class);
         when(this.gitHubMock.getRepository(REPOSITORY_NAME)).thenReturn(repositoryMock);
         when(repositoryMock.getArtifact(artifactId)).thenReturn(artifactMock);
         when(artifactMock.download(any())).thenReturn("hashsum file.jar");
@@ -147,20 +158,6 @@ class GitHubAPIAdapterTest {
         verify(this.repositoryMock).createRef(eq("refs/tags/" + v2), any());
     }
 
-    void manualExperiments() throws Exception {
-        final String credentials = RELEASE_DROID_DIRECTORY + FILE_SEPARATOR + "credentials";
-        final GitHubConnectorImpl connector = new GitHubConnectorImpl(new PropertyReaderImpl(credentials));
-        final GHRepository repository = connector.connectToGitHub().getRepository("exasol/testing-release-robot");
-        final String branch = repository.getDefaultBranch();
-        final String sha = repository.getRef("refs/heads/" + branch).getObject().getSha();
-        final PagedIterable<GHCommit> pi = repository.queryCommits().from(sha).pageSize(1).list();
-        final PagedIterator<GHCommit> it = pi.iterator();
-        while (it.hasNext()) {
-            final GHCommit commit = it.next();
-            System.out.println(commit.getCommitDate() + " sha " + commit.getSHA1());
-        }
-    }
-
     @SuppressWarnings("unchecked")
     static void mockCommits(final GHRepository repositoryMock, final boolean hasCommits) throws IOException {
         final GHRef ref = mock(GHRef.class);
@@ -206,7 +203,7 @@ class GitHubAPIAdapterTest {
     }
 
     private GHReleaseBuilder releaseBuilderMock(final GHRelease release) throws IOException {
-        final GHReleaseBuilder builder = Mockito.mock(GHReleaseBuilder.class);
+        final GHReleaseBuilder builder = mock(GHReleaseBuilder.class);
         when(builder.draft(anyBoolean())).thenReturn(builder);
         when(builder.body(any())).thenReturn(builder);
         when(builder.name(any())).thenReturn(builder);

--- a/src/test/java/com/exasol/releasedroid/main/RunnerIT.java
+++ b/src/test/java/com/exasol/releasedroid/main/RunnerIT.java
@@ -1,8 +1,7 @@
 package com.exasol.releasedroid.main;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.startsWith;
+import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
@@ -25,7 +24,7 @@ class RunnerIT {
             fail("Jar " + jar + " does not exist. Run 'mvn package' before starting the integration tests");
         }
         final String output = startCommand("java", "-jar", jar.toString(), "--help");
-        assertThat(output, startsWith(" usage:  release-droid"));
+        assertThat(output, containsString(" usage:  release-droid"));
     }
 
     private String startCommand(final String... command) throws IOException, InterruptedException {

--- a/src/test/java/com/exasol/releasedroid/progress/EstimationTest.java
+++ b/src/test/java/com/exasol/releasedroid/progress/EstimationTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.*;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Date;
 
 import org.junit.jupiter.api.Test;
 
@@ -15,10 +14,9 @@ class EstimationTest {
 
     private static final Duration DURATION = Duration.ofMinutes(1).plusSeconds(2);
     private static final Instant START = Instant.parse("2022-02-28T09:30:59.000Z");
-    private static final Date DATE1 = Date.from(START);
-    private static final Date DATE2 = Date.from(START.plus(DURATION));
+    private static final Instant END = START.plus(DURATION);
     private static final Estimation ESTIMATION_WITHOUT_TIMESTAMP = Estimation.of(DURATION);
-    private static final Estimation ESTIMATION = Estimation.from(DATE1, DATE2);
+    private static final Estimation ESTIMATION = Estimation.from(START, END);
 
     @Test
     void empty() {

--- a/src/test/java/com/exasol/releasedroid/progress/ProgressTest.java
+++ b/src/test/java/com/exasol/releasedroid/progress/ProgressTest.java
@@ -84,7 +84,6 @@ class ProgressTest {
     void status() {
         final ProgressMonitor monitor = mockProgressMonitor(ESTIMATION);
         final Duration delta = Duration.ofSeconds(3);
-
         when(monitor.elapsed()) //
                 .thenReturn(Duration.ofMillis(300)) //
                 .thenReturn(DURATION.minus(delta));

--- a/src/test/java/com/exasol/releasedroid/progress/ProgressTest.java
+++ b/src/test/java/com/exasol/releasedroid/progress/ProgressTest.java
@@ -6,13 +6,13 @@ import static com.exasol.releasedroid.usecases.ReleaseDroidConstants.FILE_SEPARA
 import static com.exasol.releasedroid.usecases.ReleaseDroidConstants.RELEASE_DROID_DIRECTORY;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.time.*;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
-import java.util.Date;
 
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.kohsuke.github.*;
-import org.mockito.Mockito;
 
 import com.exasol.releasedroid.adapter.github.*;
 import com.exasol.releasedroid.usecases.PropertyReaderImpl;
@@ -60,7 +59,7 @@ class ProgressTest {
     }
 
     @Test
-    void welcomeMessage() throws InterruptedException {
+    void welcomeMessage() {
         final String timePattern = "HH mm ss";
         final String datePattern = "dd MM YYYY";
         final Progress testee = Progress.builder() //
@@ -69,11 +68,11 @@ class ProgressTest {
                 .timePattern(timePattern) //
                 .start();
         final String prefix = "Hello";
-        final String expected = String.format(prefix + "\n" //
-                + "Last release on %s took ~ 1:01 hours.\n"
-                + "If all goes well then the current release will be finished at %s.", //
-                format(INSTANT, datePattern), //
-                format(Instant.now().plus(DURATION), timePattern));
+        final String expected = "Hello\nLast release on "
+                + format(INSTANT, datePattern)
+                + " took ~ 1:01 hours.\nIf all goes well then the current release will be finished at "
+                + format(Instant.now().plus(DURATION), timePattern)
+                + ".";
         assertThat(testee.welcomeMessage(prefix), equalTo(expected));
     }
 
@@ -82,7 +81,7 @@ class ProgressTest {
     }
 
     @Test
-    void status() throws InterruptedException {
+    void status() {
         final ProgressMonitor monitor = mockProgressMonitor(ESTIMATION);
         final Duration delta = Duration.ofSeconds(3);
 
@@ -104,14 +103,14 @@ class ProgressTest {
     }
 
     private ProgressMonitor mockProgressMonitor(final Estimation estimation) {
-        final ProgressMonitor monitor = Mockito.mock(ProgressMonitor.class);
+        final ProgressMonitor monitor = mock(ProgressMonitor.class);
         when(monitor.estimation()).thenReturn(estimation);
         when(monitor.eta()).thenReturn(INSTANT);
         return monitor;
     }
 
     @Test
-    void progress() throws InterruptedException {
+    void progress() {
         final Duration estimation = Duration.ofSeconds(1);
         final ProgressMonitor monitor = mockProgressMonitor(new Estimation(INSTANT, estimation));
         when(monitor.elapsed()) //
@@ -144,19 +143,17 @@ class ProgressTest {
         new ManualExplorer().estimation(estimation).iterations(5, 3).run(testee, "");
     }
 
-    void manualIntegrationTestWithGithub() throws IOException, GitHubException, InterruptedException {
+    void manualIntegrationTestWithGithub() throws IOException, InterruptedException {
         final String credentials = RELEASE_DROID_DIRECTORY + FILE_SEPARATOR + "credentials";
         final PropertyReaderImpl reader = new PropertyReaderImpl(credentials);
         final GitHubConnectorImpl connector = new GitHubConnectorImpl(reader);
-        final GHWorkflowRun run = lastRun(connector, "exasol/release-droid", "ci-build.yml");
+        final GHWorkflowRun run = lastRun(connector, "exasol/release-droid");
 
         final Progress testee = Progress.builder() //
                 .datePattern("dd.MM.YYYY") //
                 .estimation(Estimation.from(run.getCreatedAt(), run.getUpdatedAt())) //
                 .start();
-        final Duration estimation = Duration.between( //
-                run.getCreatedAt().toInstant(), //
-                run.getUpdatedAt().toInstant());
+        final Duration estimation = Duration.between(run.getCreatedAt(), run.getUpdatedAt());
 
         final String prefix = testee.startTime() + ": Started GitHub workflow 'ci-build.yml': " //
                 + run.getHtmlUrl() + "\n" //
@@ -165,9 +162,9 @@ class ProgressTest {
         new ManualExplorer().estimation(estimation).iterations(3, 50).run(testee, prefix);
     }
 
-    private GHWorkflowRun lastRun(final GitHubConnectorImpl connector, final String repo, final String workflowName)
+    private GHWorkflowRun lastRun(final GitHubConnectorImpl connector, final String repositoryName)
             throws IOException {
-        final GHRepository repository = connector.connectToGitHub().getRepository(repo);
+        final GHRepository repository = connector.connectToGitHub().getRepository(repositoryName);
         final GHWorkflow workflow = repository.getWorkflow("ci-build.yml");
         final GitHubAPIAdapter adapter = new GitHubAPIAdapter(connector);
         return adapter.latestRun(workflow);
@@ -178,11 +175,9 @@ class ProgressTest {
     }
 
     private Progress startProgress(final ProgressMonitor monitor, final Duration estimation) {
-        return new Progress.Builder(monitor) //
-                .estimation(Estimation.from( //
-                        Date.from(INSTANT), //
-                        Date.from(INSTANT.plus(estimation)))) //
-                .datePattern("dd.MM.YYYY") //
+        return new Progress.Builder(monitor)
+                .estimation(Estimation.from(INSTANT, INSTANT.plus(estimation)))
+                .datePattern("dd.MM.YYYY")
                 .start();
     }
 
@@ -220,7 +215,6 @@ class ProgressTest {
         private void fixEclipseConsole() {
             if (System.getProperty("sun.java.command").startsWith("org.eclipse")) {
                 System.out.println(Progress.repeat("\r\n", 70));
-                // System.out.println(new String(new char[70]).replace("\0", "\r\n"));
             }
         }
     }

--- a/src/test/java/com/exasol/releasedroid/progress/ProgressTest.java
+++ b/src/test/java/com/exasol/releasedroid/progress/ProgressTest.java
@@ -2,14 +2,11 @@ package com.exasol.releasedroid.progress;
 
 import static com.exasol.releasedroid.formatting.Colorizer.brightGreen;
 import static com.exasol.releasedroid.formatting.Colorizer.yellow;
-import static com.exasol.releasedroid.usecases.ReleaseDroidConstants.FILE_SEPARATOR;
-import static com.exasol.releasedroid.usecases.ReleaseDroidConstants.RELEASE_DROID_DIRECTORY;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
 import java.time.*;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
@@ -19,10 +16,6 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.kohsuke.github.*;
-
-import com.exasol.releasedroid.adapter.github.*;
-import com.exasol.releasedroid.usecases.PropertyReaderImpl;
 
 class ProgressTest {
 
@@ -39,6 +32,7 @@ class ProgressTest {
     }
 
     @Test
+    @SuppressWarnings("java:S8692") // testing the clock-related behavior is the point here.
     void startTime() {
         final String pattern = "HH mm ss";
         final Progress testee = progressBuilder() //
@@ -59,6 +53,7 @@ class ProgressTest {
     }
 
     @Test
+    @SuppressWarnings("java:S8692") // testing the clock-related behavior is the point here.
     void welcomeMessage() {
         final String timePattern = "HH mm ss";
         final String datePattern = "dd MM YYYY";
@@ -136,39 +131,6 @@ class ProgressTest {
         return allOf(Arrays.stream(expected).map(Matchers::containsString).toArray(Matcher[]::new));
     }
 
-    void manualIntegrationTestWithoutGithub() throws InterruptedException {
-        final Duration estimation = Duration.ofSeconds(4);
-        final Progress testee = startProgress(new ProgressMonitor(), estimation);
-        new ManualExplorer().estimation(estimation).iterations(5, 3).run(testee, "");
-    }
-
-    void manualIntegrationTestWithGithub() throws IOException, InterruptedException {
-        final String credentials = RELEASE_DROID_DIRECTORY + FILE_SEPARATOR + "credentials";
-        final PropertyReaderImpl reader = new PropertyReaderImpl(credentials);
-        final GitHubConnectorImpl connector = new GitHubConnectorImpl(reader);
-        final GHWorkflowRun run = lastRun(connector, "exasol/release-droid");
-
-        final Progress testee = Progress.builder() //
-                .datePattern("dd.MM.YYYY") //
-                .estimation(Estimation.from(run.getCreatedAt(), run.getUpdatedAt())) //
-                .start();
-        final Duration estimation = Duration.between(run.getCreatedAt(), run.getUpdatedAt());
-
-        final String prefix = testee.startTime() + ": Started GitHub workflow 'ci-build.yml': " //
-                + run.getHtmlUrl() + "\n" //
-                + "The Release Droid is monitoring its progress.\n" //
-                + "This can take from a few minutes to a couple of hours depending on the build.";
-        new ManualExplorer().estimation(estimation).iterations(3, 50).run(testee, prefix);
-    }
-
-    private GHWorkflowRun lastRun(final GitHubConnectorImpl connector, final String repositoryName)
-            throws IOException {
-        final GHRepository repository = connector.connectToGitHub().getRepository(repositoryName);
-        final GHWorkflow workflow = repository.getWorkflow("ci-build.yml");
-        final GitHubAPIAdapter adapter = new GitHubAPIAdapter(connector);
-        return adapter.latestRun(workflow);
-    }
-
     private Progress.Builder progressBuilder() {
         return Progress.builder().estimation(ESTIMATION);
     }
@@ -178,43 +140,5 @@ class ProgressTest {
                 .estimation(Estimation.from(INSTANT, INSTANT.plus(estimation)))
                 .datePattern("dd.MM.YYYY")
                 .start();
-    }
-
-    static class ManualExplorer {
-        private Duration estimation = Duration.ofSeconds(2);
-        private int iterations = 5;
-        private int intervals = 3;
-
-        public ManualExplorer estimation(final Duration value) {
-            this.estimation = value;
-            return this;
-        }
-
-        public ManualExplorer iterations(final int iterations, final int intervals) {
-            this.iterations = iterations;
-            this.intervals = intervals;
-            return this;
-        }
-
-        // class is only used for manual exploration
-        // Sonar warnings are suppressed therefore:
-        // java:S2925 - "Thread.sleep" should not be used in tests
-        @SuppressWarnings("java:S2925")
-        public void run(final Progress testee, final String prefix) throws InterruptedException {
-            System.out.println(testee.welcomeMessage(prefix));
-            for (int i = 0; i < this.iterations; i++) {
-                Thread.sleep(this.estimation.dividedBy(this.intervals).toMillis());
-                fixEclipseConsole();
-                System.out.print("\r" + testee.status());
-                System.out.flush();
-            }
-            System.out.println();
-        }
-
-        private void fixEclipseConsole() {
-            if (System.getProperty("sun.java.command").startsWith("org.eclipse")) {
-                System.out.println(Progress.repeat("\r\n", 70));
-            }
-        }
     }
 }


### PR DESCRIPTION
It updates dependencies to fix the following vulnerabilities:
* Closes https://github.com/exasol/release-droid/issues/314 (CVE-2026-8484)
* Closes https://github.com/exasol/release-droid/issues/315 (CVE-2025-48924)
* Closes https://github.com/exasol/release-droid/issues/316 (CVE-2025-41242)
* Closes https://github.com/exasol/release-droid/issues/317 (CVE-2025-41249)
* Closes https://github.com/exasol/release-droid/issues/318 (CVE-2026-22745)
* Closes https://github.com/exasol/release-droid/issues/319 (CVE-2026-41842)
* Closes https://github.com/exasol/release-droid/issues/320 (CVE-2026-41848)
* Closes https://github.com/exasol/release-droid/issues/321 (CVE-2026-41853)
* Closes https://github.com/exasol/release-droid/issues/322 (CVE-2026-54515)
* Closes https://github.com/exasol/release-droid/issues/323 (CVE-2026-59889)